### PR TITLE
Test/#64 천지인 삭제 회귀 검증 보강

### DIFF
--- a/SYKeyboardTests/Processor/CheonjiinProcessorTests.swift
+++ b/SYKeyboardTests/Processor/CheonjiinProcessorTests.swift
@@ -382,6 +382,11 @@ struct CheonjiinProcessorTests: HangeulProcessorTestable {
         
         #expect(failureCount == 0, "총 \(failureCount)개의 글자에서 생성 또는 삭제 실패")
     }
+
+    @Test("완성형 한글이 아닌 글자의 예상 삭제 횟수는 0")
+    func test비한글_예상삭제횟수() {
+        #expect(calculateExpectedDeleteCount(for: "A") == 0)
+    }
 }
 
 // MARK: - Private Methods
@@ -500,7 +505,8 @@ private extension CheonjiinProcessorTests {
 
     /// 완성형 한글 한 글자를 모두 지우기 위해 필요한 백스페이스 횟수를 계산
     func calculateExpectedDeleteCount(for char: Character) -> Int {
-        guard let scalar = char.unicodeScalars.first else { return 0 }
+        guard let scalar = char.unicodeScalars.first,
+              (0xAC00...0xD7A3).contains(scalar.value) else { return 0 }
         let code = Int(scalar.value) - 0xAC00
 
         let 중성Index = (code % (21 * 28)) / 28

--- a/SYKeyboardTests/Processor/CheonjiinProcessorTests.swift
+++ b/SYKeyboardTests/Processor/CheonjiinProcessorTests.swift
@@ -271,6 +271,75 @@ struct CheonjiinProcessorTests: HangeulProcessorTestable {
         (c, p) = applyInput(인, committed: c, composing: p)
         #expect(c + p == "가녀", "비표준 모음 삭제 후 표준 모음 조합 시 연음이 발생해야 합니다.")
     }
+
+    @Test("비표준 모음 포함 composing은 마지막 글자만 삭제")
+    func test비표준모음_Composing삭제() {
+        let cases = [
+            (composing: "ㆍ", expected: ""),
+            (composing: "ᆢ", expected: ""),
+            (composing: "간ㆍ", expected: "간"),
+            (composing: "간ᆢ", expected: "간")
+        ]
+
+        for testCase in cases {
+            let result = processor.delete(
+                composing: testCase.composing,
+                committedTail: "",
+                isProtected: false
+            )
+
+            #expect(
+                result.composing == testCase.expected,
+                "'\(testCase.composing)' 삭제 결과가 '\(testCase.expected)'여야 합니다."
+            )
+            #expect(result.consumedCommittedCount == 0)
+        }
+    }
+
+    @Test("committed 비표준 모음 복원은 보호되지 않은 경우에만 committed를 소비")
+    func test비표준모음_Committed복원() {
+        let cases = [
+            (
+                composing: "ㄷ",
+                committedTail: "간ㆍ",
+                isProtected: false,
+                expectedComposing: "간ㆍ",
+                expectedConsumedCount: 2
+            ),
+            (
+                composing: "다",
+                committedTail: "간ᆢ",
+                isProtected: false,
+                expectedComposing: "간ᆢㄷ",
+                expectedConsumedCount: 2
+            ),
+            (
+                composing: "ㄷ",
+                committedTail: "간ㆍ",
+                isProtected: true,
+                expectedComposing: "",
+                expectedConsumedCount: 0
+            ),
+            (
+                composing: "다",
+                committedTail: "간ᆢ",
+                isProtected: true,
+                expectedComposing: "ㄷ",
+                expectedConsumedCount: 0
+            )
+        ]
+
+        for testCase in cases {
+            let result = processor.delete(
+                composing: testCase.composing,
+                committedTail: testCase.committedTail,
+                isProtected: testCase.isProtected
+            )
+
+            #expect(result.composing == testCase.expectedComposing)
+            #expect(result.consumedCommittedCount == testCase.expectedConsumedCount)
+        }
+    }
     
     // MARK: - 6. 11,172자 전체 검증 (Heavy Test)
     
@@ -294,10 +363,24 @@ struct CheonjiinProcessorTests: HangeulProcessorTestable {
             if committed + composing != targetString {
                 Self.logger.error("실패: \(targetString) (생성됨: \(committed + composing)) / 입력키: \(keySequence)")
                 failureCount += 1
+                continue
+            }
+
+            let expectedDeleteCount = calculateExpectedDeleteCount(for: char)
+
+            for _ in 0..<expectedDeleteCount {
+                (committed, composing) = applyDelete(committed: committed, composing: composing)
+            }
+
+            if !(committed + composing).isEmpty {
+                Self.logger.error(
+                    "삭제 실패: \(targetString) -> 예상 삭제 횟수(\(expectedDeleteCount)) 실행 후 잔여물: '\(committed + composing)'"
+                )
+                failureCount += 1
             }
         }
         
-        #expect(failureCount == 0, "총 \(failureCount)개의 글자 생성 실패")
+        #expect(failureCount == 0, "총 \(failureCount)개의 글자에서 생성 또는 삭제 실패")
     }
 }
 
@@ -413,5 +496,27 @@ private extension CheonjiinProcessorTests {
         case 27: return ["ㅅ", "ㅅ"]
         default: return []
         }
+    }
+
+    /// 완성형 한글 한 글자를 모두 지우기 위해 필요한 백스페이스 횟수를 계산
+    func calculateExpectedDeleteCount(for char: Character) -> Int {
+        guard let scalar = char.unicodeScalars.first else { return 0 }
+        let code = Int(scalar.value) - 0xAC00
+
+        let 중성Index = (code % (21 * 28)) / 28
+        let 종성Index = code % 28
+
+        let 중성Deletes = [
+            1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 3, 2, 1, 1, 2, 3, 2, 1, 1, 2, 1
+        ]
+        let 겹받침Indices = Set([3, 5, 6, 9, 10, 11, 12, 13, 14, 15, 18])
+
+        var count = 1 + 중성Deletes[중성Index]
+
+        if 종성Index != 0 {
+            count += 겹받침Indices.contains(종성Index) ? 2 : 1
+        }
+
+        return count
     }
 }

--- a/dev/active/code-review-scope/code-review-scope-findings.md
+++ b/dev/active/code-review-scope/code-review-scope-findings.md
@@ -60,13 +60,19 @@ Last Updated: 2026-06-14
 - 판단: 사용자 확인 결과 이 동작은 의도된 동작이다. 따라서 버그 finding이 아니며 수정 대상에서 제외한다.
 - 검증: 사용자 확인. 추가 코드 검증 없음.
 
-#### [P3][Open] 천지인 전체 문자 테스트가 삭제 경로를 검증하지 않음
+#### [P3][Resolved] 천지인 전체 문자 테스트가 삭제 경로를 검증하지 않음
 
 - 위치: `SYKeyboardTests/Processor/CheonjiinProcessorTests.swift:277`
 - 영향: 천지인은 비표준 모음과 `committedTail` 복원 삭제 로직이 별도로 있는데, 전체 11,172자 테스트는 생성만 검증해서 겹모음/겹받침 삭제 회귀가 넓게 노출되지 않는다.
 - 근거: `CheonjiinProcessorTests.validateAllCharacters()`는 입력 후 `committed + composing`이 목표 글자인지만 확인한다. 두벌식 전체 테스트는 생성 후 삭제 루프까지 검증하고, 나랏글 전체 테스트도 예상 삭제 횟수만큼 삭제 후 잔여물을 확인한다.
 - 제안: 천지인도 전체 문자 생성 뒤 삭제 루프를 추가하거나, 최소한 겹받침/복합모음/비표준 모음 중간상태를 포함한 삭제 매트릭스를 보강한다.
-- 검증: `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
+- 처리: 완성형 글자의 중성/종성 구조 기반 예상 삭제 횟수를 계산해 11,172자 생성 후 전체 삭제를 검증하도록 보강했다. 완성형 전체 삭제로 검증할 수 없는 `ㆍ`/`ᆢ` composing 삭제와 `committedTail` 복원, `consumedCommittedCount`, `isProtected` 계약은 별도 매트릭스로 추가했다. production 코드는 변경하지 않았다.
+- 검증:
+  - 일반 샌드박스 targeted 테스트는 CoreSimulator/Xcode 캐시 권한 오류로 실패했다.
+  - 권한 있는 환경의 `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/CheonjiinProcessorTests`는 정상 코드에서 `TEST SUCCEEDED`를 확인했다.
+  - 비표준 모음 삭제가 진행되지 않도록 임시 mutation한 상태에서 새 `test비표준모음_Composing삭제()`가 실패함을 확인한 뒤 production 코드를 원복했다.
+  - production 원복 후 같은 천지인 targeted 테스트를 fresh 재실행해 `TEST SUCCEEDED`를 확인했다.
+  - 권한 있는 환경의 `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` 전체 테스트도 `TEST SUCCEEDED`를 확인했다.
 
 ### Track 2. Common Keyboard Interaction Runtime
 

--- a/dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-context.md
+++ b/dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-context.md
@@ -1,0 +1,46 @@
+# Issue 64 Cheonjiin Delete Tests Context
+
+Last Updated: 2026-06-14
+
+## Relevant Files
+
+- `SYKeyboardTests/Processor/CheonjiinProcessorTests.swift`
+- `SYKeyboardTests/Utils/HangeulProcessorTestable.swift`
+- `Modules/HangeulKeyboardCore/Domain/Processor/CheonjiinProcessor.swift`
+- `dev/active/code-review-scope/code-review-scope-findings.md`
+
+## Facts Checked
+
+- GitHub issue #64는 천지인 전체 문자 테스트의 삭제 경로 누락을 다룬다.
+- 현재 heavy test 이름은 생성 및 삭제 검증이지만 실제 구현은 생성만 검증한다.
+- `CheonjiinProcessor.delete(...)`는 composing에 비표준 모음이 있으면 마지막 문자를 직접 제거한다.
+- committed 끝이 비표준 모음일 때 복원하는 경로는 `consumedCommittedCount`와 `isProtected`에 의존한다.
+- 완성형 11,172자 생성 결과에는 `ㆍ`, `ᆢ`가 남지 않으므로 별도 매트릭스가 필요하다.
+- 작업 시작 시 `git status --short --untracked-files=all`는 비어 있었다.
+
+## Decisions
+
+- production 코드는 수정하지 않는다.
+- 전체 문자 삭제는 천지인 입력 키 개수가 아니라 완성형 글자의 중성·종성 구조 기반 예상 삭제 횟수를 사용한다.
+- 천지인 고유 삭제 경로는 Processor 직접 호출 매트릭스로 검증한다.
+
+## Verification Notes
+
+- 일반 샌드박스 targeted 테스트는 CoreSimulator/Xcode/SwiftPM 캐시 권한 오류로 실패했다.
+- 권한 있는 환경의 천지인 targeted 테스트는 정상 코드에서 `TEST SUCCEEDED`였다.
+- 첫 임시 mutation인 `composingContains비표준모음(...) == false`는 테스트가 통과했다. 확인 결과 현재 매트릭스 입력에서는 오토마타도 같은 외부 삭제 결과를 만들므로 분기 사용 여부 자체를 검증하지 않는다.
+- 두 번째 임시 mutation인 비표준 모음 삭제 시 `remaining = composing`에서는 `test비표준모음_Composing삭제()` 실패를 확인했다.
+- 두 번째 mutation 실행은 테스트 실패 확인 후 xcodebuild 종료 정리에서 멈춰 중단했고, production 코드는 원복했다.
+- `git diff -- Modules/HangeulKeyboardCore/Domain/Processor/CheonjiinProcessor.swift` 출력이 비어 production 변경이 남지 않았음을 확인했다.
+- production 원복 후 권한 있는 환경에서 천지인 targeted 테스트를 fresh 재실행해 `TEST SUCCEEDED`를 확인했다.
+- 권한 있는 환경에서 전체 `SYKeyboard` 테스트를 실행해 `TEST SUCCEEDED`를 확인했다.
+
+## Current Uncommitted State
+
+- `SYKeyboardTests/Processor/CheonjiinProcessorTests.swift`
+- `dev/active/code-review-scope/code-review-scope-findings.md`
+- `dev/active/issue-64-cheonjiin-delete-tests/`
+
+## Next Action
+
+- 구현과 검증이 완료됐다. findings 상태를 `Resolved`로 반영했다.

--- a/dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-plan.md
+++ b/dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-plan.md
@@ -1,0 +1,51 @@
+# Issue 64 Cheonjiin Delete Tests Plan
+
+Last Updated: 2026-06-14
+
+## Goal
+
+- 천지인 Processor의 완성형 한글 삭제와 천지인 고유 비표준 모음 삭제 경로에 대한 회귀 테스트를 보강한다.
+- 키보드 앱의 production 동작은 변경하지 않는다.
+
+## Current State
+
+- `SYKeyboardTests/Processor/CheonjiinProcessorTests.swift`의 11,172자 heavy test는 생성만 검증한다.
+- `ㆍ`, `ᆢ`, `committedTail`, `consumedCommittedCount`, `isProtected` 경로는 전체 완성형 문자 삭제 루프로 검증할 수 없다.
+
+## Approach
+
+1. 완성형 한글의 중성·종성 구조를 기준으로 예상 삭제 횟수를 계산한다.
+2. 천지인 11,172자 생성 성공 후 예상 횟수만큼 삭제하여 잔여물이 없는지 검증한다.
+3. 천지인 고유 비표준 모음 삭제와 committed 복원 계약은 별도 매트릭스로 검증한다.
+4. 임시 production mutation으로 새 테스트가 실제 회귀를 검출하는지 확인한 뒤 mutation을 복구한다.
+5. 전체 `SYKeyboard` 테스트 결과를 findings 문서에 반영한다.
+
+## Risks
+
+- 천지인 키 입력 횟수와 삭제 횟수는 일치하지 않는다. 자음 순환 입력 횟수를 삭제 횟수로 사용하지 않는다.
+- 완성형 한글 전체 삭제 테스트는 `ㆍ`, `ᆢ`가 남아 있는 중간 상태를 검증하지 못한다.
+- `isProtected`는 Processor 단위에서 직접 호출해 계약을 검증하고, production controller 동작은 변경하지 않는다.
+
+## Verification
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/CheonjiinProcessorTests
+```
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+## Done Criteria
+
+- production Swift 파일이 변경되지 않는다.
+- 천지인 11,172자 전체 생성 및 삭제 검증이 통과한다.
+- 비표준 모음과 committed 복원 삭제 매트릭스가 통과한다.
+- findings 문서의 #64 finding이 검증 결과와 함께 `Resolved`로 변경된다.

--- a/dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-tasks.md
+++ b/dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-tasks.md
@@ -1,0 +1,13 @@
+# Issue 64 Cheonjiin Delete Tests Tasks
+
+Last Updated: 2026-06-14
+
+- [x] GitHub issue #64와 관련 finding을 확인한다.
+- [x] 천지인 Processor 삭제 구현과 기존 Processor 테스트를 비교한다.
+- [x] 천지인 고유 비표준 모음 삭제 매트릭스를 추가한다.
+- [x] 11,172자 heavy test에 구조 기반 전체 삭제 검증을 추가한다.
+- [x] 새 테스트가 임시 production mutation을 검출하는지 확인하고 mutation을 복구한다.
+- [x] production 원복 후 천지인 Processor 테스트를 fresh 재실행한다.
+- [x] 전체 `SYKeyboard` 테스트를 실행한다.
+- [x] findings 문서에 현재 처리와 검증 결과를 반영한다.
+- [x] production 코드가 변경되지 않았는지 확인한다.

--- a/dev/active/issue-64-cheonjiin-delete-tests/superpowers/plans/2026-06-14-issue-64-cheonjiin-delete-tests.md
+++ b/dev/active/issue-64-cheonjiin-delete-tests/superpowers/plans/2026-06-14-issue-64-cheonjiin-delete-tests.md
@@ -1,0 +1,87 @@
+# Issue 64 Cheonjiin Delete Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 천지인 Processor의 완성형 한글 삭제와 비표준 모음 복원 경로를 production 동작 변경 없이 회귀 테스트로 보호한다.
+
+**Architecture:** 기존 `CheonjiinProcessorTests`와 `HangeulProcessorTestable` 헬퍼를 재사용한다. 완성형 전체 삭제는 글자 구조 기반 예상 삭제 횟수로 검증하고, 비표준 모음 및 committed 복원 계약은 Processor 직접 호출 매트릭스로 분리한다.
+
+**Tech Stack:** Swift 5, Swift Testing, Xcode 16, iOS 16 Simulator
+
+---
+
+### Task 1: 천지인 고유 삭제 계약 검증
+
+**Files:**
+- Modify: `SYKeyboardTests/Processor/CheonjiinProcessorTests.swift`
+
+- [ ] **Step 1: 비표준 모음 composing 삭제 테스트를 추가한다**
+
+`ㆍ`, `ᆢ`, `간ㆍ`, `간ᆢ`에서 삭제 후 기대 composing을 검증한다.
+
+- [ ] **Step 2: committed 비표준 모음 복원 매트릭스를 추가한다**
+
+`committedTail`, `remaining`, `isProtected`, 예상 `composing`, 예상 `consumedCommittedCount`를 매트릭스로 검증한다.
+
+- [ ] **Step 3: targeted 테스트를 실행한다**
+
+Run:
+
+```sh
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/CheonjiinProcessorTests
+```
+
+Expected: `TEST SUCCEEDED`
+
+### Task 2: 천지인 11,172자 전체 삭제 검증
+
+**Files:**
+- Modify: `SYKeyboardTests/Processor/CheonjiinProcessorTests.swift`
+
+- [ ] **Step 1: 구조 기반 예상 삭제 횟수 helper를 추가한다**
+
+초성 1회, 중성 분해 단계, 종성 단일/겹받침 단계를 더해 삭제 횟수를 반환한다.
+
+- [ ] **Step 2: heavy test 생성 성공 후 삭제 루프를 추가한다**
+
+생성 실패 문자는 `continue`하고, 예상 삭제 횟수 후 잔여물이 없어야 한다.
+
+- [ ] **Step 3: 임시 production mutation으로 테스트 실패를 확인한다**
+
+천지인 삭제의 겹받침 또는 비표준 모음 경로를 임시 변경해 새 테스트가 실패하는지 확인하고 즉시 복구한다.
+
+- [ ] **Step 4: targeted 테스트를 다시 실행한다**
+
+Expected: `TEST SUCCEEDED`
+
+### Task 3: 전체 검증과 findings 갱신
+
+**Files:**
+- Modify: `dev/active/code-review-scope/code-review-scope-findings.md`
+- Modify: `dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-context.md`
+- Modify: `dev/active/issue-64-cheonjiin-delete-tests/issue-64-cheonjiin-delete-tests-tasks.md`
+
+- [ ] **Step 1: 전체 테스트를 실행한다**
+
+Run:
+
+```sh
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+Expected: `TEST SUCCEEDED`
+
+- [ ] **Step 2: findings를 Resolved로 갱신한다**
+
+추가한 테스트 범위와 실제 검증 결과를 기록한다.
+
+- [ ] **Step 3: 변경 범위를 확인한다**
+
+Run:
+
+```sh
+git status --short
+git diff --check
+```
+
+Expected: production Swift 파일 변경 없음, whitespace 오류 없음


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #64
- 상위 이슈: #57

<br>

## 📝 작업 내용
- 천지인 11,172자 전체 생성 검증에 구조 기반 전체 삭제 검증을 추가했습니다.
- `ㆍ`/`ᆢ` composing 삭제와 `committedTail`, `consumedCommittedCount`, `isProtected` 복원 계약 테스트를 추가했습니다.
- Track 1 finding 처리 결과와 검증 기록을 작업 문서에 반영했습니다.
- production 키보드 코드는 변경하지 않았습니다.

<br>

## ✅ 검증
- 일반 샌드박스 targeted 테스트: CoreSimulator/Xcode/SwiftPM 캐시 권한 오류로 실행 실패
- 권한 있는 환경: `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/CheonjiinProcessorTests`
  - 결과: `TEST SUCCEEDED`
- 권한 있는 환경: `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - 결과: `TEST SUCCEEDED`
- `git diff --check`
  - 결과: 통과

<br>
