### PR TITLE
Fix/#65 취소된 키보드 제스처 결과 확정 방지

### DIFF
--- a/Modules/SYKeyboardCore/Presentation/Utils/ButtonStateController.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/ButtonStateController.swift
@@ -75,8 +75,15 @@ final public class ButtonStateController {
     func setExclusiveActionToButtons(_ buttonList: [BaseKeyboardButton]) {
         buttonList.forEach { button in
             let buttonReleaseAction: UIAction
+            let buttonCancelAction: UIAction
             if button is ShiftButton {
                 buttonReleaseAction = UIAction { [weak self] _ in
+                    self?.isShiftButtonPressed = false
+                }
+                buttonCancelAction = UIAction { [weak self] action in
+                    guard let senderButton = action.sender as? BaseKeyboardButton,
+                          senderButton.isGesturing == false else { return }
+
                     self?.isShiftButtonPressed = false
                 }
             } else {
@@ -87,8 +94,17 @@ final public class ButtonStateController {
                         self?.currentPressedButton = nil
                     }
                 }
+                buttonCancelAction = UIAction { [weak self] action in
+                    guard let senderButton = action.sender as? BaseKeyboardButton,
+                          senderButton.isGesturing == false else { return }
+
+                    if self?.currentPressedButton == senderButton {
+                        self?.currentPressedButton = nil
+                    }
+                }
             }
             button.addAction(buttonReleaseAction, for: [.touchUpInside, .touchUpOutside])
+            button.addAction(buttonCancelAction, for: .touchCancel)
         }
     }
 }

--- a/Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/SwitchGestureController.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/SwitchGestureController.swift
@@ -111,13 +111,14 @@ final class SwitchGestureController: NSObject {
             onkeyboardSelectPanGestureChanged(gesture, config: config)
         case .ended, .cancelled, .failed:
             // 순서 중요
+            let shouldCommit = gesture.state == .ended
             lockedPanDirection = nil
-            if !isOverlayActive && switchButton.isGesturing {
+            if shouldCommit && !isOverlayActive && switchButton.isGesturing {
                 switchButton.sendActions(for: .touchUpInside)
             }
             setCurrentPressedButton(nil)
             
-            onkeyboardSelectPanGestureEnded(gesture, config: config)
+            onkeyboardSelectPanGestureEnded(gesture, config: config, shouldCommit: shouldCommit)
             isOverlayActive = false
             switchButton.isGesturing = false
             
@@ -153,13 +154,14 @@ final class SwitchGestureController: NSObject {
             onOneHandedModeSelectPanGestureChanged(gesture, config: config)
         case .ended, .cancelled, .failed:
             // 순서 중요
+            let shouldCommit = gesture.state == .ended
             lockedPanDirection = nil
-            if !isOverlayActive && switchButton.isGesturing {
+            if shouldCommit && !isOverlayActive && switchButton.isGesturing {
                 switchButton.sendActions(for: .touchUpInside)
             }
             setCurrentPressedButton(nil)
             
-            onOneHandedModeSelectPanGestureEnded(gesture, config: config)
+            onOneHandedModeSelectPanGestureEnded(gesture, config: config, shouldCommit: shouldCommit)
             isOverlayActive = false
             switchButton.isGesturing = false
             
@@ -192,13 +194,16 @@ final class SwitchGestureController: NSObject {
             onLongPressGestureChanged(gesture, config: config)
         case .ended, .cancelled, .failed:
             // 순서 중요
-            if gesture.state == .cancelled {
-                logger.debug("길게 누르기 제스처 취소")
-            } else {
+            let shouldCommit = gesture.state == .ended
+            if getCurrentPressedButton() === switchButton {
                 setCurrentPressedButton(nil)
-                logger.debug("길게 누르기 제스처 비활성화")
             }
-            onLongPressGestureEnded(gesture, config: config)
+            if shouldCommit {
+                logger.debug("길게 누르기 제스처 비활성화")
+            } else {
+                logger.debug("길게 누르기 제스처 취소")
+            }
+            onLongPressGestureEnded(gesture, config: config, shouldCommit: shouldCommit)
             switchButton.isGesturing = isKeepGesturing
             if isKeepGesturing { config.gestureHandler.disableAllButtonUserInteraction() }
             
@@ -219,7 +224,11 @@ final class SwitchGestureController: NSObject {
         case .changed:
             onkeyboardHStackViewPressGestureChanged(gesture, gestureHandler: gestureHandler)
         case .ended, .cancelled, .failed:
-            onkeyboardHStackViewPressGestureEnded(gesture, gestureHandler: gestureHandler)
+            onkeyboardHStackViewPressGestureEnded(
+                gesture,
+                gestureHandler: gestureHandler,
+                shouldCommit: gesture.state == .ended
+            )
             switchButton.isGesturing = false
             gestureHandler.enableAllButtonUserInteraction()
             logger.debug("키보드 길게 누르기 제스처 비활성화")
@@ -265,7 +274,7 @@ private extension SwitchGestureController {
         }
     }
     
-    func onkeyboardSelectPanGestureEnded(_ gesture: UIPanGestureRecognizer, config: PanConfig) {
+    func onkeyboardSelectPanGestureEnded(_ gesture: UIPanGestureRecognizer, config: PanConfig, shouldCommit: Bool) {
         let switchButton = config.gestureHandler.switchButton
         let keyboardSelectOverlayView = config.gestureHandler.keyboardSelectOverlayView
         let oneHandedModeSelectOverlayView = config.gestureHandler.oneHandedModeSelectOverlayView
@@ -274,7 +283,8 @@ private extension SwitchGestureController {
             endKeyboardSelect(keyboardSelectOverlayView,
                               gesture: gesture,
                               config: config,
-                              switchButton: switchButton)
+                              switchButton: switchButton,
+                              shouldCommit: shouldCommit)
             
         }
     }
@@ -316,7 +326,7 @@ private extension SwitchGestureController {
         }
     }
     
-    func onOneHandedModeSelectPanGestureEnded(_ gesture: UIPanGestureRecognizer, config: PanConfig) {
+    func onOneHandedModeSelectPanGestureEnded(_ gesture: UIPanGestureRecognizer, config: PanConfig, shouldCommit: Bool) {
         let switchButton = config.gestureHandler.switchButton
         let keyboardSelectOverlayView = config.gestureHandler.keyboardSelectOverlayView
         let oneHandedModeSelectOverlayView = config.gestureHandler.oneHandedModeSelectOverlayView
@@ -325,7 +335,8 @@ private extension SwitchGestureController {
             endOneHandedModeSelect(oneHandedModeSelectOverlayView,
                                    gesture: gesture,
                                    config: config,
-                                   switchButton: switchButton)
+                                   switchButton: switchButton,
+                                   shouldCommit: shouldCommit)
         }
     }
 }
@@ -352,13 +363,19 @@ private extension SwitchGestureController {
         }
     }
     
-    func onLongPressGestureEnded(_ gesture: UILongPressGestureRecognizer, config: PanConfig) {
+    func onLongPressGestureEnded(_ gesture: UILongPressGestureRecognizer, config: PanConfig, shouldCommit: Bool) {
         let switchButton = config.gestureHandler.switchButton
         let keyboardSelectOverlayView = config.gestureHandler.keyboardSelectOverlayView
         let oneHandedModeSelectOverlayView = config.gestureHandler.oneHandedModeSelectOverlayView
         
         if !oneHandedModeSelectOverlayView.isHidden && keyboardSelectOverlayView.isHidden {
-            endOneHandedModeSelect(oneHandedModeSelectOverlayView, gesture: gesture, config: config, switchButton: switchButton)
+            endOneHandedModeSelect(
+                oneHandedModeSelectOverlayView,
+                gesture: gesture,
+                config: config,
+                switchButton: switchButton,
+                shouldCommit: shouldCommit
+            )
         }
         
         isDragOutside = false
@@ -383,7 +400,11 @@ private extension SwitchGestureController {
         }
     }
     
-    func onkeyboardHStackViewPressGestureEnded(_ gesture: UILongPressGestureRecognizer, gestureHandler: SwitchGestureHandling) {
+    func onkeyboardHStackViewPressGestureEnded(
+        _ gesture: UILongPressGestureRecognizer,
+        gestureHandler: SwitchGestureHandling,
+        shouldCommit: Bool
+    ) {
         let switchButton = gestureHandler.switchButton
         let oneHandedModeSelectOverlayView = gestureHandler.oneHandedModeSelectOverlayView
         
@@ -394,7 +415,9 @@ private extension SwitchGestureController {
                                                             targetMaxX: oneHandedModeSelectOverlayView.rightKeyboardImageContainerView.frame.minX,
                                                             targetRect: oneHandedModeSelectOverlayView.bounds)
             
-            delegate?.changeOneHandedMode(self, to: selectOneHandedModeOverlay(panDirection: panDirection))
+            if shouldCommit {
+                delegate?.changeOneHandedMode(self, to: selectOneHandedModeOverlay(panDirection: panDirection))
+            }
             gestureHandler.hideOneHandedModeSelectOverlay()
             switchButton.configureOneHandedComponent(needToEmphasize: false)
             
@@ -546,12 +569,18 @@ private extension SwitchGestureController {
         config.gestureHandler.showKeyboardSelectOverlay(needToEmphasizeTarget: panDirection == config.keyboardSelectTargetDirection)
     }
     
-    func endKeyboardSelect(_ keyboardSelectOverlayView: KeyboardSelectOverlayView, gesture: UIGestureRecognizer, config: PanConfig, switchButton: SwitchButton) {
+    func endKeyboardSelect(
+        _ keyboardSelectOverlayView: KeyboardSelectOverlayView,
+        gesture: UIGestureRecognizer,
+        config: PanConfig,
+        switchButton: SwitchButton,
+        shouldCommit: Bool
+    ) {
         let xmarkRect = keyboardSelectOverlayView.xmarkImageContainerView.frame
         let panLocation = gesture.location(in: keyboardSelectOverlayView)
         let panDirection = checkKeyboardSelectPanDirection(panLocation: panLocation, xmarkRect: xmarkRect, targetDirection: config.keyboardSelectTargetDirection)
         
-        if panDirection == config.keyboardSelectTargetDirection {
+        if shouldCommit && panDirection == config.keyboardSelectTargetDirection {
             delegate?.changeKeyboard(self, to: config.keyboardSelectTargetkeyboard)
         }
         config.gestureHandler.hideKeyboardSelectOverlay()
@@ -578,7 +607,20 @@ private extension SwitchGestureController {
         config.gestureHandler.showOneHandedModeSelectOverlay(of: targetOneHandedMode)
     }
     
-    func endOneHandedModeSelect(_ oneHandedModeSelectOverlayView: OneHandedModeSelectOverlayView, gesture: UIGestureRecognizer, config: PanConfig, switchButton: SwitchButton) {
+    func endOneHandedModeSelect(
+        _ oneHandedModeSelectOverlayView: OneHandedModeSelectOverlayView,
+        gesture: UIGestureRecognizer,
+        config: PanConfig,
+        switchButton: SwitchButton,
+        shouldCommit: Bool
+    ) {
+        guard shouldCommit else {
+            config.gestureHandler.hideOneHandedModeSelectOverlay()
+            switchButton.configureOneHandedComponent(needToEmphasize: false)
+            isKeepGesturing = false
+            return
+        }
+
         let panLocation = gesture.location(in: oneHandedModeSelectOverlayView)
         let panDirection = checkOneHandModePanDirection(panLocation: panLocation,
                                                         targetMinX: oneHandedModeSelectOverlayView.leftKeyboardImageContainerView.frame.maxX,

--- a/Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/TextInteractionGestureController.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/TextInteractionGestureController.swift
@@ -88,8 +88,11 @@ final class TextInteractionGestureController: NSObject {
             }
         case .ended, .cancelled, .failed:
             // 순서 중요
-            if isCursorActive {
-                setCurrentPressedButton(nil)
+            if isCursorActive || gesture.state != .ended {
+                if let gestureButton = gestureButton as? BaseKeyboardButton,
+                   getCurrentPressedButton() === gestureButton {
+                    setCurrentPressedButton(nil)
+                }
             } else {
                 gestureButton?.sendActions(for: .touchUpInside)
             }

--- a/SYKeyboardTests/Utils/ButtonStateControllerTests.swift
+++ b/SYKeyboardTests/Utils/ButtonStateControllerTests.swift
@@ -1,0 +1,112 @@
+//
+//  ButtonStateControllerTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Testing
+import UIKit
+
+@testable import SYKeyboardCore
+
+@Suite("버튼 상태 컨트롤러 검증")
+@MainActor
+struct ButtonStateControllerTests {
+
+    @Test("일반 버튼 touchCancel은 눌림 상태를 해제하고 다음 버튼이 이전 입력을 실행하지 않음")
+    func test일반버튼_TouchCancel() {
+        let keyboardHStackView = UIStackView()
+        let suggestionBarView = SuggestionBarView(keyboardHStackView: keyboardHStackView)
+        let controller = ButtonStateController(suggestionBarView: suggestionBarView)
+        let firstButton = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        let secondButton = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄴ"], secondary: nil)
+        )
+        var firstButtonInputCount = 0
+
+        firstButton.addAction(
+            UIAction { _ in firstButtonInputCount += 1 },
+            for: .touchUpInside
+        )
+        controller.setFeedbackActionToButtons([firstButton, secondButton])
+        controller.setExclusiveActionToButtons([firstButton, secondButton])
+
+        firstButton.sendActions(for: .touchDown)
+        #expect(controller.currentPressedButton === firstButton)
+        #expect(suggestionBarView.isUserInteractionEnabled == false)
+
+        firstButton.sendActions(for: .touchCancel)
+        #expect(controller.currentPressedButton == nil)
+        #expect(suggestionBarView.isUserInteractionEnabled)
+
+        secondButton.sendActions(for: .touchDown)
+        #expect(firstButtonInputCount == 0)
+        #expect(controller.currentPressedButton === secondButton)
+    }
+
+    @Test("Shift touchCancel은 눌림 상태를 해제")
+    func testShift_TouchCancel() {
+        let keyboardHStackView = UIStackView()
+        let suggestionBarView = SuggestionBarView(keyboardHStackView: keyboardHStackView)
+        let controller = ButtonStateController(suggestionBarView: suggestionBarView)
+        let shiftButton = ShiftButton(keyboard: .dubeolsik)
+
+        controller.setFeedbackActionToButtons([shiftButton])
+        controller.setExclusiveActionToButtons([shiftButton])
+
+        shiftButton.sendActions(for: .touchDown)
+        #expect(controller.isShiftButtonPressed)
+
+        shiftButton.sendActions(for: .touchCancel)
+        #expect(controller.isShiftButtonPressed == false)
+    }
+
+    @Test("제스처가 시작된 일반 버튼 touchCancel은 눌림 상태와 recognizer를 유지")
+    func test일반버튼_제스처중TouchCancel() {
+        let keyboardHStackView = UIStackView()
+        let suggestionBarView = SuggestionBarView(keyboardHStackView: keyboardHStackView)
+        let controller = ButtonStateController(suggestionBarView: suggestionBarView)
+        let button = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        let gesture = UIPanGestureRecognizer()
+
+        button.addGestureRecognizer(gesture)
+        controller.setFeedbackActionToButtons([button])
+        controller.setExclusiveActionToButtons([button])
+
+        button.sendActions(for: .touchDown)
+        button.isGesturing = true
+        gesture.state = .began
+
+        button.sendActions(for: .touchCancel)
+
+        #expect(controller.currentPressedButton === button)
+        #expect(gesture.state == .began)
+        #expect(suggestionBarView.isUserInteractionEnabled == false)
+    }
+
+    @Test("제스처가 시작된 Shift touchCancel은 눌림 상태를 유지")
+    func testShift_제스처중TouchCancel() {
+        let keyboardHStackView = UIStackView()
+        let suggestionBarView = SuggestionBarView(keyboardHStackView: keyboardHStackView)
+        let controller = ButtonStateController(suggestionBarView: suggestionBarView)
+        let shiftButton = ShiftButton(keyboard: .dubeolsik)
+
+        controller.setFeedbackActionToButtons([shiftButton])
+        controller.setExclusiveActionToButtons([shiftButton])
+
+        shiftButton.sendActions(for: .touchDown)
+        shiftButton.isGesturing = true
+
+        shiftButton.sendActions(for: .touchCancel)
+
+        #expect(controller.isShiftButtonPressed)
+    }
+}

--- a/SYKeyboardTests/Utils/SwitchGestureControllerTests.swift
+++ b/SYKeyboardTests/Utils/SwitchGestureControllerTests.swift
@@ -1,0 +1,200 @@
+//
+//  SwitchGestureControllerTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Testing
+import UIKit
+
+@testable import SYKeyboardCore
+
+@Suite("키보드 전환 제스처 컨트롤러 검증")
+@MainActor
+struct SwitchGestureControllerTests {
+
+    @Test("정상 종료된 키보드 선택 pan은 전환을 확정")
+    func test정상종료된키보드선택Pan() {
+        let environment = makeEnvironment()
+        let gesture = UIPanGestureRecognizer()
+
+        environment.handler.showKeyboardSelectOverlay(needToEmphasizeTarget: true)
+        environment.handler.switchButton.addGestureRecognizer(gesture)
+        gesture.state = .ended
+
+        environment.controller.keyboardSelectPanGestureHandler(gesture)
+
+        #expect(environment.delegate.changedKeyboards == [.numeric])
+        #expect(environment.handler.keyboardSelectOverlayView.isHidden)
+    }
+
+    @Test("취소된 키보드 선택 pan은 전환하지 않고 overlay를 정리")
+    func test취소된키보드선택Pan() {
+        let environment = makeEnvironment()
+        let gesture = UIPanGestureRecognizer()
+
+        environment.handler.showKeyboardSelectOverlay(needToEmphasizeTarget: true)
+        environment.handler.switchButton.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        environment.controller.keyboardSelectPanGestureHandler(gesture)
+
+        #expect(environment.delegate.changedKeyboards.isEmpty)
+        #expect(environment.handler.keyboardSelectOverlayView.isHidden)
+        #expect(environment.currentPressedButton() == nil)
+        #expect(environment.keyboardHStackView.isUserInteractionEnabled)
+    }
+
+    @Test("취소된 한 손 모드 pan은 모드를 변경하지 않고 overlay를 정리")
+    func test취소된한손모드Pan() {
+        let environment = makeEnvironment()
+        let gesture = UIPanGestureRecognizer()
+
+        environment.handler.showOneHandedModeSelectOverlay(of: .center)
+        environment.handler.switchButton.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        environment.controller.oneHandedModeSelectPanGestureHandler(gesture)
+
+        #expect(environment.delegate.changedOneHandedModes.isEmpty)
+        #expect(environment.handler.oneHandedModeSelectOverlayView.isHidden)
+        #expect(environment.currentPressedButton() == nil)
+        #expect(environment.keyboardHStackView.isUserInteractionEnabled)
+    }
+
+    @Test("실패한 키보드 선택 pan은 전환하지 않고 overlay를 정리")
+    func test실패한키보드선택Pan() {
+        let environment = makeEnvironment()
+        let gesture = UIPanGestureRecognizer()
+
+        environment.handler.showKeyboardSelectOverlay(needToEmphasizeTarget: true)
+        environment.handler.switchButton.addGestureRecognizer(gesture)
+        gesture.state = .failed
+
+        environment.controller.keyboardSelectPanGestureHandler(gesture)
+
+        #expect(environment.delegate.changedKeyboards.isEmpty)
+        #expect(environment.handler.keyboardSelectOverlayView.isHidden)
+        #expect(environment.currentPressedButton() == nil)
+    }
+
+    @Test("취소된 한 손 모드 long press는 모드를 변경하지 않고 overlay를 정리")
+    func test취소된한손모드LongPress() {
+        let environment = makeEnvironment()
+        let gesture = UILongPressGestureRecognizer()
+
+        environment.handler.showOneHandedModeSelectOverlay(of: .center)
+        environment.handler.switchButton.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        environment.controller.oneHandedModeLongPressGestureHandler(gesture)
+
+        #expect(environment.delegate.changedOneHandedModes.isEmpty)
+        #expect(environment.handler.oneHandedModeSelectOverlayView.isHidden)
+        #expect(environment.currentPressedButton() == nil)
+        #expect(environment.keyboardHStackView.isUserInteractionEnabled)
+    }
+
+    @Test("취소된 연속 한 손 모드 long press는 모드를 변경하지 않고 overlay를 정리")
+    func test취소된연속한손모드LongPress() {
+        let environment = makeEnvironment()
+        let gesture = UILongPressGestureRecognizer()
+
+        environment.handler.showOneHandedModeSelectOverlay(of: .center)
+        environment.keyboardHStackView.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        environment.controller.keyboardHStackViewPressGestureHandler(gesture)
+
+        #expect(environment.delegate.changedOneHandedModes.isEmpty)
+        #expect(environment.handler.oneHandedModeSelectOverlayView.isHidden)
+        #expect(environment.handler.switchButton.isGesturing == false)
+    }
+
+    @Test("다른 버튼이 눌린 상태에서 취소된 한 손 모드 long press는 현재 버튼을 해제하지 않음")
+    func test취소된한손모드LongPress_다른현재버튼보존() {
+        let otherButton = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        let environment = makeEnvironment(currentPressedButton: otherButton)
+        let gesture = UILongPressGestureRecognizer()
+
+        environment.handler.switchButton.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        environment.controller.oneHandedModeLongPressGestureHandler(gesture)
+
+        #expect(environment.currentPressedButton() === otherButton)
+    }
+}
+
+@MainActor
+private extension SwitchGestureControllerTests {
+    struct Environment {
+        let keyboardHStackView: UIView
+        let handler: SwitchGestureHandlingSpy
+        let delegate: SwitchGestureDelegateSpy
+        let controller: SwitchGestureController
+        let currentPressedButton: () -> BaseKeyboardButton?
+    }
+
+    func makeEnvironment(currentPressedButton initialCurrentPressedButton: BaseKeyboardButton? = nil) -> Environment {
+        let keyboardHStackView = UIView()
+        let handler = SwitchGestureHandlingSpy()
+        let delegate = SwitchGestureDelegateSpy()
+        var currentPressedButton: BaseKeyboardButton? = initialCurrentPressedButton ?? handler.switchButton
+        let controller = SwitchGestureController(
+            keyboardHStackView: keyboardHStackView,
+            hangeulKeyboardView: handler,
+            englishKeyboardView: nil,
+            symbolKeyboardView: handler,
+            numericKeyboardView: handler,
+            getCurrentKeyboard: { .dubeolsik },
+            getCurrentOneHandedMode: { .center },
+            getCurrentPressedButton: { currentPressedButton },
+            setCurrentPressedButton: { currentPressedButton = $0 }
+        )
+
+        controller.delegate = delegate
+
+        return Environment(
+            keyboardHStackView: keyboardHStackView,
+            handler: handler,
+            delegate: delegate,
+            controller: controller,
+            currentPressedButton: { currentPressedButton }
+        )
+    }
+}
+
+@MainActor
+private final class SwitchGestureHandlingSpy: SwitchGestureHandling {
+    let switchButton = SwitchButton(keyboard: .dubeolsik)
+    let keyboardSelectOverlayView = KeyboardSelectOverlayView(keyboard: .dubeolsik)
+    let oneHandedModeSelectOverlayView = OneHandedModeSelectOverlayView()
+
+    init() {
+        keyboardSelectOverlayView.isHidden = true
+        oneHandedModeSelectOverlayView.isHidden = true
+    }
+
+    func enableAllButtonUserInteraction() {}
+
+    func disableAllButtonUserInteraction() {}
+}
+
+@MainActor
+private final class SwitchGestureDelegateSpy: SwitchGestureControllerDelegate {
+    var changedKeyboards: [SYKeyboardType] = []
+    var changedOneHandedModes: [OneHandedMode] = []
+
+    func changeKeyboard(_ controller: SwitchGestureController, to newKeyboard: SYKeyboardType) {
+        changedKeyboards.append(newKeyboard)
+    }
+
+    func changeOneHandedMode(_ controller: SwitchGestureController, to newMode: OneHandedMode) {
+        changedOneHandedModes.append(newMode)
+    }
+}

--- a/SYKeyboardTests/Utils/TextInteractionGestureControllerTests.swift
+++ b/SYKeyboardTests/Utils/TextInteractionGestureControllerTests.swift
@@ -1,0 +1,165 @@
+//
+//  TextInteractionGestureControllerTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Testing
+import UIKit
+
+@testable import SYKeyboardCore
+
+@Suite("텍스트 상호작용 제스처 컨트롤러 검증")
+@MainActor
+struct TextInteractionGestureControllerTests {
+
+    @Test("정상 종료된 짧은 pan은 입력을 확정")
+    func test정상종료된짧은Pan() {
+        let keyboardHStackView = UIView()
+        let button = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        var currentPressedButton: BaseKeyboardButton? = button
+        var inputCount = 0
+        let controller = TextInteractionGestureController(
+            keyboardHStackView: keyboardHStackView,
+            getCurrentPressedButton: { currentPressedButton },
+            setCurrentPressedButton: { currentPressedButton = $0 }
+        )
+        let gesture = UIPanGestureRecognizer()
+
+        button.addAction(UIAction { _ in inputCount += 1 }, for: .touchUpInside)
+        button.addGestureRecognizer(gesture)
+        gesture.state = .ended
+
+        controller.panGestureHandler(gesture)
+
+        #expect(inputCount == 1)
+    }
+
+    @Test("취소된 짧은 pan은 입력하지 않고 눌린 버튼을 해제")
+    func test취소된짧은Pan() {
+        let keyboardHStackView = UIView()
+        let button = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        var currentPressedButton: BaseKeyboardButton? = button
+        var inputCount = 0
+        let controller = TextInteractionGestureController(
+            keyboardHStackView: keyboardHStackView,
+            getCurrentPressedButton: { currentPressedButton },
+            setCurrentPressedButton: { currentPressedButton = $0 }
+        )
+        let gesture = UIPanGestureRecognizer()
+
+        button.addAction(UIAction { _ in inputCount += 1 }, for: .touchUpInside)
+        button.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        controller.panGestureHandler(gesture)
+
+        #expect(inputCount == 0)
+        #expect(currentPressedButton == nil)
+        #expect(button.isGesturing == false)
+        #expect(keyboardHStackView.isUserInteractionEnabled)
+    }
+
+    @Test("취소된 삭제 pan은 입력하지 않고 stop callback을 호출")
+    func test취소된삭제Pan() {
+        let keyboardHStackView = UIView()
+        let button = DeleteButton(keyboard: .dubeolsik)
+        var currentPressedButton: BaseKeyboardButton? = button
+        var inputCount = 0
+        let delegate = TextInteractionGestureDelegateSpy()
+        let controller = TextInteractionGestureController(
+            keyboardHStackView: keyboardHStackView,
+            getCurrentPressedButton: { currentPressedButton },
+            setCurrentPressedButton: { currentPressedButton = $0 }
+        )
+        let gesture = UIPanGestureRecognizer()
+
+        controller.delegate = delegate
+        button.addAction(UIAction { _ in inputCount += 1 }, for: .touchUpInside)
+        button.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        controller.panGestureHandler(gesture)
+
+        #expect(inputCount == 0)
+        #expect(currentPressedButton == nil)
+        #expect(delegate.deletePanStoppedCount == 1)
+    }
+
+    @Test("실패한 짧은 pan은 입력하지 않고 눌린 버튼을 해제")
+    func test실패한짧은Pan() {
+        let keyboardHStackView = UIView()
+        let button = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        var currentPressedButton: BaseKeyboardButton? = button
+        var inputCount = 0
+        let controller = TextInteractionGestureController(
+            keyboardHStackView: keyboardHStackView,
+            getCurrentPressedButton: { currentPressedButton },
+            setCurrentPressedButton: { currentPressedButton = $0 }
+        )
+        let gesture = UIPanGestureRecognizer()
+
+        button.addAction(UIAction { _ in inputCount += 1 }, for: .touchUpInside)
+        button.addGestureRecognizer(gesture)
+        gesture.state = .failed
+
+        controller.panGestureHandler(gesture)
+
+        #expect(inputCount == 0)
+        #expect(currentPressedButton == nil)
+    }
+
+    @Test("취소된 pan은 다른 현재 눌린 버튼을 해제하지 않음")
+    func test취소된Pan_다른현재버튼보존() {
+        let keyboardHStackView = UIView()
+        let gestureButton = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄱ"], secondary: nil)
+        )
+        let otherButton = PrimaryKeyButton(
+            keyboard: .dubeolsik,
+            button: .keyButton(primary: ["ㄴ"], secondary: nil)
+        )
+        var currentPressedButton: BaseKeyboardButton? = otherButton
+        let controller = TextInteractionGestureController(
+            keyboardHStackView: keyboardHStackView,
+            getCurrentPressedButton: { currentPressedButton },
+            setCurrentPressedButton: { currentPressedButton = $0 }
+        )
+        let gesture = UIPanGestureRecognizer()
+
+        gestureButton.addGestureRecognizer(gesture)
+        gesture.state = .cancelled
+
+        controller.panGestureHandler(gesture)
+
+        #expect(currentPressedButton === otherButton)
+    }
+}
+
+@MainActor
+private final class TextInteractionGestureDelegateSpy: TextInteractionGestureControllerDelegate {
+    var deletePanStoppedCount = 0
+
+    func primaryButtonPanning(_ controller: TextInteractionGestureController, to direction: PanDirection, steps: Int) {}
+
+    func deleteButtonPanning(_ controller: TextInteractionGestureController, to direction: PanDirection) {}
+
+    func deleteButtonPanStopped(_ controller: TextInteractionGestureController) {
+        deletePanStoppedCount += 1
+    }
+
+    func textInteractableButtonLongPressing(_ controller: TextInteractionGestureController, button: TextInteractable) {}
+
+    func textInteractableButtonLongPressStopped(_ controller: TextInteractionGestureController, button: TextInteractable) {}
+}

--- a/dev/active/code-review-scope/code-review-scope-findings.md
+++ b/dev/active/code-review-scope/code-review-scope-findings.md
@@ -76,29 +76,43 @@ Last Updated: 2026-06-14
 
 ### Track 2. Common Keyboard Interaction Runtime
 
-#### [P1][Open] 취소된 텍스트 팬 제스처가 정상 키 입력을 실행함
+#### [P1][Resolved] 취소된 텍스트 팬 제스처가 정상 키 입력을 실행함
 
 - 위치: `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/TextInteractionGestureController.swift:89`
 - 영향: 문자 또는 스페이스 버튼에서 짧은 드래그가 시스템이나 다른 제스처에 의해 취소되면, 사용자가 확정하지 않은 키가 입력될 수 있다.
 - 근거: `.ended`, `.cancelled`, `.failed`가 같은 분기를 사용하고, 커서 이동이 활성화되지 않은 경우 `sendActions(for: .touchUpInside)`를 호출한다. 이 호출은 `BaseKeyboardButton.isProgrammaticCall`을 활성화하므로 `BaseKeyboardViewController.makeTextInputAction()`의 현재 눌린 버튼 검증을 우회하고 입력을 수행한다.
 - 제안: `.ended`만 짧은 팬을 탭으로 확정하고, `.cancelled`/`.failed`는 입력 없이 상태만 정리한다. 제스처 상태별 입력 횟수를 검증하는 interaction test를 추가한다.
-- 검증: 코드 경로 확인. 현재 테스트에는 `TextInteractionGestureController`의 `.cancelled`/`.failed` 상태 검증이 없다.
+- 처리: `.ended`만 짧은 팬의 `.touchUpInside`를 전송하고, `.cancelled`/`.failed`는 해당 gesture button이 현재 눌린 버튼일 때만 해제하도록 변경했다. 삭제 pan의 stop callback과 UI 상호작용 복구는 terminal 상태와 무관하게 유지했다.
+- 검증:
+  - `TextInteractionGestureControllerTests`에서 정상 종료 입력, 취소/실패 입력 차단, 삭제 pan stop callback, 다른 현재 버튼 보존을 확인했다.
+  - 권한 있는 환경의 집중 interaction 테스트와 전체 `SYKeyboard` 테스트에서 `TEST SUCCEEDED`를 확인했다.
 
-#### [P1][Open] `touchCancel`이 버튼 눌림 상태를 해제하지 않아 다음 터치에서 이전 키를 입력할 수 있음
+#### [P1][Resolved] `touchCancel`이 버튼 눌림 상태를 해제하지 않아 다음 터치에서 이전 키를 입력할 수 있음
 
 - 위치: `Modules/SYKeyboardCore/Presentation/Utils/ButtonStateController.swift:91`
 - 영향: 터치가 중단되면 suggestion bar가 비활성 상태로 남거나 Shift가 계속 눌린 것으로 처리될 수 있다. 다음 버튼의 `touchDown`에서 취소된 이전 버튼의 `.touchUpInside`가 실행되어 의도하지 않은 키/리턴 입력도 발생할 수 있다.
 - 근거: 버튼 해제 action은 `.touchUpInside`, `.touchUpOutside`에만 등록되어 있고 `.touchCancel`에는 등록되지 않는다. 이후 다른 버튼을 누르면 `currentPressedButton`에 남은 이전 버튼에 `sendActions(for: .touchUpInside)`를 호출하며, programmatic call은 입력 action의 현재 버튼 검증을 우회한다.
 - 제안: `.touchCancel`에서도 일반 버튼의 `currentPressedButton`과 Shift의 `isShiftButtonPressed`를 정리한다. 취소 후 suggestion bar 활성 상태와 다음 버튼 입력 횟수를 검증하는 테스트를 추가한다.
-- 검증: 코드 경로 확인. 현재 테스트에는 `ButtonStateController`의 UIControl event 상태 전이 검증이 없다.
+- 처리: 일반 버튼과 Shift 버튼에 `.touchCancel` 전용 action을 추가했다. 일반 터치 취소는 상태를 해제하되, 활성 recognizer가 터치 소유권을 얻으며 발생시킨 `.touchCancel`은 `isGesturing`으로 구분해 유지하고 terminal gesture handler가 정리하도록 했다.
+- 검증:
+  - `ButtonStateControllerTests`에서 일반 버튼 취소 후 눌림/suggestion bar 복구와 다음 버튼이 이전 입력을 실행하지 않는지 확인했다.
+  - Shift 취소 후 `isShiftButtonPressed == false`를 확인했다.
+  - 첫 구현 후 실기기에서 길게 누르기 반복 입력과 커서 드래그가 즉시 종료되는 회귀를 확인했다.
+  - 활성 제스처 중 일반 버튼/Shift `.touchCancel`이 상태를 유지하는 테스트가 첫 구현에서 실패함을 확인하고 조건부 해제 로직을 추가했다.
+  - 조건부 해제 수정 후 권한 있는 환경의 집중 interaction 테스트에서 `TEST SUCCEEDED`를 확인했다.
+  - 사용자 실기기 확인에서 길게 누르기 반복 입력과 버튼 영역 밖 커서 드래그가 정상 동작함을 확인했다.
 
-#### [P2][Open] 취소된 키보드 전환 제스처가 전환 결과를 확정할 수 있음
+#### [P2][Resolved] 취소된 키보드 전환 제스처가 전환 결과를 확정할 수 있음
 
 - 위치: `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/SwitchGestureController.swift:112`, `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/SwitchGestureController.swift:193`
 - 영향: 키보드 선택 또는 한 손 모드 드래그/길게 누르기가 중단되어도 키보드 종류나 한 손 모드가 바뀔 수 있다.
 - 근거: 팬의 `.cancelled`/`.failed`가 `.ended`와 같은 완료 경로를 실행해 `.touchUpInside`와 `on...GestureEnded`를 호출한다. 완료 helper는 현재 위치에 따라 `changeKeyboard` 또는 `changeOneHandedMode` delegate를 호출한다. 취소된 long press도 동일하게 종료 helper를 호출한다.
 - 제안: 취소/실패 시 overlay와 버튼 상태만 정리하고 delegate 변경은 `.ended`에서만 확정한다. overlay가 표시된 상태에서 각 제스처를 취소하는 테스트를 추가한다.
-- 검증: 코드 경로 확인. 현재 테스트에는 `SwitchGestureController` 취소 상태 검증이 없다.
+- 처리: 키보드 선택 pan, 한 손 모드 pan, initial/continuation long press에서 `.ended`만 `.touchUpInside`와 delegate 변경을 확정하도록 분리했다. 취소/실패 시 overlay, 강조, gesture 상태, 버튼 상호작용은 정리하며 다른 현재 눌린 버튼은 보존한다.
+- 검증:
+  - `SwitchGestureControllerTests`에서 정상 종료 전환, 취소/실패 결과 차단, keyboard/one-handed overlay 정리, initial/continuation long press 취소, 다른 현재 버튼 보존을 확인했다.
+  - 권한 있는 환경의 집중 interaction 테스트와 전체 `SYKeyboard` 테스트에서 `TEST SUCCEEDED`를 확인했다.
+  - 권한 있는 환경에서 `HangeulKeyboard`, `EnglishKeyboard` scheme 빌드 모두 `BUILD SUCCEEDED`를 확인했다.
 
 ### Track 3. Keyboard Layout, Views, And Assets
 

--- a/dev/active/issue-65-common-keyboard-interaction-runtime/issue-65-common-keyboard-interaction-runtime-context.md
+++ b/dev/active/issue-65-common-keyboard-interaction-runtime/issue-65-common-keyboard-interaction-runtime-context.md
@@ -1,0 +1,94 @@
+# Issue 65 Common Keyboard Interaction Runtime Context
+
+Last Updated: 2026-06-14
+
+## Relevant Files
+
+- `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/TextInteractionGestureController.swift`: 텍스트 버튼 pan/long press의 상태 전이와 입력 확정을 담당한다.
+- `Modules/SYKeyboardCore/Presentation/Utils/ButtonStateController.swift`: 현재 눌린 버튼, Shift 눌림 상태, suggestion bar 상호작용을 관리한다.
+- `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/SwitchGestureController.swift`: 키보드 선택과 한 손 모드 pan/long press 및 overlay 상태를 관리한다.
+- `Modules/SYKeyboardCore/Presentation/View/Components/Buttons/Bases/BaseKeyboardButton.swift`: 코드 기반 `sendActions(for:)` 호출 중 `isProgrammaticCall`을 활성화한다.
+- `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift`: `isProgrammaticCall`이면 현재 눌린 버튼 검증 없이 텍스트 입력을 수행한다.
+- `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/Protocols/SwitchGestureHandling.swift`: 키보드 선택 및 한 손 모드 overlay 표시/숨김 계약을 정의한다.
+- `SYKeyboardTests/Utils/KeyboardGesturePolicyTests.swift`: 현재 gesture 관련 테스트 패턴을 보여 주지만 취소 interaction은 검증하지 않는다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`: issue #65가 처리할 Track 2 findings 원본이다.
+
+## Facts Checked
+
+- GitHub issue #65의 본문과 Track 2 findings 문서에는 동일한 세 finding이 기록되어 있고 댓글은 없다.
+- 작업 시작 시 `git status --short` 출력은 비어 있었다.
+- `TextInteractionGestureController.panGestureHandler(_:)`는 `.ended`, `.cancelled`, `.failed`를 같은 분기에서 처리한다.
+- 짧은 텍스트 팬의 terminal 분기는 cursor가 활성화되지 않았으면 `gestureButton?.sendActions(for: .touchUpInside)`를 호출한다.
+- `BaseKeyboardButton.sendActions(for:)`는 호출 중 `isProgrammaticCall = true`로 설정한다.
+- `BaseKeyboardViewController.makeTextInputAction()`은 `isProgrammaticCall == true`이면 `currentPressedButton` 일치 확인 없이 입력을 수행한다.
+- `ButtonStateController.setExclusiveActionToButtons(_:)`는 해제 action을 `.touchUpInside`, `.touchUpOutside`에만 등록한다.
+- 첫 수정에서 `.touchCancel`을 기존 release action에 함께 등록하면, recognizer가 시작될 때 UIKit이 전달하는 `.touchCancel`도 현재 버튼을 해제한다.
+- `currentPressedButton`의 `didSet`은 이전 버튼의 모든 recognizer 상태를 `.cancelled`로 변경한다.
+- 실기기에서 첫 수정 후 길게 누르기 반복 입력은 글자 하나와 햅틱 한 번 뒤 종료됐고, 커서 드래그는 손가락이 버튼 영역을 벗어나는 순간 종료됐다.
+- 활성 제스처 중 `.touchCancel`을 무시하면 terminal gesture handler가 기존처럼 버튼, recognizer, 사용자 상호작용 상태를 정리한다.
+- 다음 버튼의 `.touchDown`은 이전 `currentPressedButton`이 남아 있으면 이전 버튼에 `.touchUpInside`를 전송한다.
+- 일반 버튼의 `currentPressedButton = nil`은 이전 버튼의 눌림 표시를 해제하고 suggestion bar 상호작용을 다시 활성화한다.
+- `SwitchGestureController`의 키보드 선택 pan, 한 손 모드 pan, 한 손 모드 long press, keyboard stack continuation long press는 terminal 상태에서 취소/실패와 정상 종료를 같은 완료 경로로 처리한다.
+- `endKeyboardSelect(...)`, `endOneHandedModeSelect(...)`, `onkeyboardHStackViewPressGestureEnded(...)`는 현재 위치에 따라 delegate 변경을 호출한다.
+- 현재 `SYKeyboardTests`에는 `TextInteractionGestureController`, `ButtonStateController`, `SwitchGestureController`의 UIControl/recognizer 취소 상태 전이 테스트가 없다.
+- `SYKeyboardTests`는 `@testable import SYKeyboardCore`와 Swift Testing을 사용하며, gesture 관련 pure policy 테스트 패턴은 이미 존재한다.
+
+## Review Evaluation
+
+- 세 finding은 현재 코드 경로에서 성립하므로 수정 대상이다.
+- issue의 제안처럼 `.ended`만 결과를 확정해야 한다.
+- 제안에 추가로, 취소/실패 시 결과 확정만 생략하면 안 되고 stale pressed state, overlay, 강조, 상호작용 잠금, drag/long-press stop 상태를 함께 정리해야 한다.
+- `SwitchGestureController`는 issue에 명시된 팬 및 one-handed long press뿐 아니라 이어지는 `keyboardHStackViewPressGestureHandler(_:)`의 취소 상태도 같은 원칙으로 처리해야 한다. 그렇지 않으면 continuation recognizer 취소 시 한 손 모드 변경이 남는다.
+
+## Decisions
+
+- 정상 `.ended`와 `.cancelled`/`.failed`를 명시적으로 분리한다.
+- 취소/실패에서는 사용자 결과를 확정하지 않지만 cleanup과 stop callback은 수행한다.
+- 전환 제스처는 결과 확정 helper와 취소 cleanup helper의 책임을 분리한다.
+- 테스트는 결과 호출 횟수와 cleanup 상태를 함께 검증한다. pure policy 테스트만 추가하고 실제 action/delegate 횟수 검증을 생략하지 않는다.
+- production 공개 API는 늘리지 않는다. 테스트 가능성을 위한 분리가 필요하면 internal 범위의 최소 helper를 사용한다.
+- 일반 터치 취소와 recognizer 소유권 전환에 따른 취소를 `BaseKeyboardButton.isGesturing`으로 구분한다.
+
+## Open Questions
+
+- 실제 입력 앱에서 시스템 또는 다른 recognizer가 제스처를 취소하는 흐름이 자동 테스트와 동일하게 overlay와 입력 상태를 복구하는지 수동 확인이 남아 있다.
+
+## Verification Notes
+
+- 일반 샌드박스의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 CoreSimulator/Xcode/SwiftPM 캐시 권한 오류로 실패했다.
+- TDD RED:
+  - `ButtonStateControllerTests`의 일반 버튼/Shift `touchCancel` 테스트가 현재 코드에서 실패함을 확인했다.
+  - `TextInteractionGestureControllerTests`의 취소된 짧은/delete pan 테스트가 현재 코드에서 실패함을 확인했다.
+  - `SwitchGestureControllerTests`의 keyboard/one-handed pan과 initial/continuation long press 취소 테스트가 현재 코드에서 실패함을 확인했다.
+  - 다른 현재 버튼 보존 테스트가 첫 cleanup 구현에서 실패함을 확인하고 cleanup 범위를 gesture button으로 좁혔다.
+- 권한 있는 환경의 집중 interaction 테스트는 최종 코드에서 `TEST SUCCEEDED`였다.
+- 권한 있는 환경의 전체 `SYKeyboard` 테스트는 최종 코드에서 `TEST SUCCEEDED`였다.
+- 권한 있는 환경의 `HangeulKeyboard`, `EnglishKeyboard` scheme 빌드는 최종 코드에서 모두 `BUILD SUCCEEDED`였다.
+- 첫 구현의 실제 입력 앱 확인에서 길게 누르기 반복 입력과 커서 드래그 회귀가 발견됐다.
+- 회귀 TDD RED:
+  - 활성 제스처 중 일반 버튼 `.touchCancel`이 `currentPressedButton`과 recognizer 상태를 유지해야 하는 테스트가 첫 구현에서 실패함을 확인했다.
+  - 활성 제스처 중 Shift `.touchCancel`이 눌림 상태를 유지해야 하는 테스트가 첫 구현에서 실패함을 확인했다.
+- 조건부 `.touchCancel` 수정 후 집중 테스트의 일반 샌드박스 실행은 CoreSimulator/SwiftPM 캐시 권한 오류로 중단됐다.
+- 권한 있는 환경에서 조건부 `.touchCancel` 수정 후 집중 interaction 테스트를 재실행해 `TEST SUCCEEDED`를 확인했다.
+- 사용자 실기기 확인에서 조건부 `.touchCancel` 수정 후 길게 누르기 반복 입력과 버튼 영역 밖 커서 드래그가 정상 동작함을 확인했다.
+- 확인한 이슈: `https://github.com/SNMac/SYKeyboard/issues/65`
+- 확인한 프로젝트 지침:
+  - `dev/README.md`
+  - `dev/codex-skill-playbook.md`의 `ios-keyboard-extension`, `docs-and-infrastructure`
+  - `dev/coding-conventions.md`의 UIKit 키보드 UI 및 테스트 스타일
+
+## Current Uncommitted State
+
+- `Modules/SYKeyboardCore/Presentation/Utils/ButtonStateController.swift`
+- `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/TextInteractionGestureController.swift`
+- `Modules/SYKeyboardCore/Presentation/Utils/GestureControllers/SwitchGestureController.swift`
+- `SYKeyboardTests/Utils/ButtonStateControllerTests.swift`
+- `SYKeyboardTests/Utils/TextInteractionGestureControllerTests.swift`
+- `SYKeyboardTests/Utils/SwitchGestureControllerTests.swift`
+- `dev/active/code-review-scope/code-review-scope-findings.md`
+- `dev/active/issue-65-common-keyboard-interaction-runtime/`
+
+## Next Action
+
+- 권한 있는 환경에서 interaction 테스트, 전체 테스트, 한글/영문 extension 빌드를 다시 실행한다.
+- 나머지 취소/정상 종료 흐름을 실제 입력 앱에서 확인한다.

--- a/dev/active/issue-65-common-keyboard-interaction-runtime/issue-65-common-keyboard-interaction-runtime-plan.md
+++ b/dev/active/issue-65-common-keyboard-interaction-runtime/issue-65-common-keyboard-interaction-runtime-plan.md
@@ -1,0 +1,129 @@
+# Issue 65 Common Keyboard Interaction Runtime Plan
+
+Last Updated: 2026-06-14
+
+## Goal
+
+- 취소되거나 실패한 키보드 터치/제스처가 입력, 키보드 전환, 한 손 모드 변경을 확정하지 않도록 한다.
+- 정상 종료된 탭과 제스처의 기존 입력 흐름, 버튼 이벤트 순서, overlay 정리 동작은 유지한다.
+- GitHub issue #65의 Track 2 findings 세 건을 회귀 테스트와 함께 처리한다.
+
+## Current State
+
+- `TextInteractionGestureController.panGestureHandler(_:)`는 `.ended`만 짧은 pan 입력을 확정하고, 취소/실패 시 해당 gesture button의 눌림 상태만 정리한다.
+- `ButtonStateController.setExclusiveActionToButtons(_:)`는 일반 터치의 `.touchCancel`에서 버튼 상태를 해제하되, 활성 제스처가 UIKit에 의해 발생시킨 `.touchCancel`은 무시한다.
+- `SwitchGestureController`의 팬 및 long press 종료 경로는 `.ended`만 입력 action과 delegate 변경을 확정하고, 취소/실패 시 overlay와 상호작용 상태만 정리한다.
+- 관련 controller의 취소/실패/정상 종료 상태 전이를 검증하는 interaction 테스트가 추가됐다.
+- 첫 구현은 모든 `.touchCancel`에서 현재 버튼 상태를 해제해 실기기에서 길게 누르기 반복 입력과 커서 드래그 recognizer까지 취소하는 회귀가 발생했다. 활성 제스처 중 취소를 보존하는 회귀 테스트와 조건부 해제 로직을 추가했다.
+
+## Approach
+
+### 1. 취소 상태의 공통 원칙 확정
+
+- `.ended`만 사용자가 확정한 동작으로 취급한다.
+- `.cancelled`와 `.failed`는 입력 action과 delegate 변경을 수행하지 않는다.
+- 취소/실패에서도 눌림 상태, gesture 상태, overlay, 강조 표시, 사용자 상호작용 잠금, 반복 입력/드래그 종료 상태는 정리한다.
+- `.ended`의 기존 버튼 입력과 키보드/한 손 모드 전환 결과는 유지한다.
+
+### 2. 텍스트 팬 제스처 종료 경로 분리
+
+- `TextInteractionGestureController.panGestureHandler(_:)`에서 `.ended`와 `.cancelled`/`.failed`를 분리한다.
+- 짧은 팬의 `.touchUpInside` 전송은 `.ended`에서만 수행한다.
+- 취소/실패 시 `currentPressedButton`을 해제해 다음 버튼 터치가 이전 버튼을 입력하지 않도록 한다.
+- 커서 이동 또는 삭제 드래그가 시작된 경우에는 종료 상태와 무관하게 필요한 stop callback과 UI 상호작용 복구를 수행한다.
+
+### 3. 버튼 `touchCancel` 해제 처리 추가
+
+- `ButtonStateController.setExclusiveActionToButtons(_:)`의 일반 버튼과 Shift 버튼에 `.touchCancel` 전용 action을 등록한다.
+- 일반 버튼 취소 시 해당 버튼이 현재 눌린 버튼일 때만 `currentPressedButton`을 비운다.
+- Shift 취소 시 `isShiftButtonPressed`를 `false`로 복구한다.
+- 단, `isGesturing == true`인 버튼의 `.touchCancel`은 recognizer가 터치 소유권을 얻으면서 발생한 이벤트이므로 상태를 유지하고, 실제 terminal gesture handler가 정리하도록 한다.
+- suggestion bar의 `isUserInteractionEnabled`가 취소 후 다시 활성화되는지 확인한다.
+
+### 4. 전환 제스처의 결과 확정과 정리 분리
+
+- `SwitchGestureController`의 다음 종료 경로에서 `.ended`만 결과를 확정하도록 분리한다.
+  - `keyboardSelectPanGestureHandler(_:)`
+  - `oneHandedModeSelectPanGestureHandler(_:)`
+  - `oneHandedModeLongPressGestureHandler(_:)`
+  - `keyboardHStackViewPressGestureHandler(_:)`
+- 취소/실패 시 `.touchUpInside`, `changeKeyboard`, `changeOneHandedMode`를 호출하지 않는다.
+- 취소/실패 전용 정리 경로에서 표시 중인 overlay를 숨기고, switch button 강조와 `isGesturing`, `isOverlayActive`, `isDragOutside`, `isKeepGesturing`, 눌린 버튼, 사용자 상호작용 상태를 일관되게 복구한다.
+- 정상 `.ended`의 overlay 선택 및 one-handed mode 유지 제스처 전환은 기존 동작을 보존한다.
+
+### 5. Interaction 회귀 테스트 추가
+
+- `ButtonStateController`는 실제 `UIControl.sendActions(for:)`를 사용해 일반 버튼과 Shift 버튼의 `.touchCancel` 상태 전이를 검증한다.
+- `TextInteractionGestureController`는 `.ended`, `.cancelled`, `.failed`별 `.touchUpInside` 입력 횟수, 눌린 버튼 해제, 삭제 드래그 stop callback을 검증한다.
+- `SwitchGestureController`는 overlay가 표시된 상태에서 각 팬/long press가 `.ended`일 때만 delegate를 호출하고, `.cancelled`/`.failed`에서는 delegate 호출 없이 overlay와 상호작용 상태만 정리되는지 검증한다.
+- UIKit recognizer를 안정적으로 구동하기 어렵다면 넓은 추상화 대신 controller 내부의 terminal-state 결정/정리 helper를 최소 범위로 분리하고, handler 연결과 결과 횟수를 함께 검증한다.
+
+### 6. Findings와 검증 결과 반영
+
+- 세 finding을 각각 수정 및 검증한 뒤 `dev/active/code-review-scope/code-review-scope-findings.md`에 처리 내용과 실제 검증 결과를 기록한다.
+
+## Risks
+
+- `BaseKeyboardButton.sendActions(for:)`는 `isProgrammaticCall`을 켜 입력 검증을 우회하므로 취소 경로에서 호출이 한 번이라도 남으면 의도하지 않은 입력이 발생한다.
+- 취소 시 `currentPressedButton`을 정리하지 않으면 다음 버튼의 `touchDown`이 이전 버튼 입력을 확정할 수 있다.
+- 텍스트 삭제 드래그와 long press 반복 입력은 취소 시에도 stop callback이 필요하다. 결과 확정을 막으면서 타이머/드래그 상태 정리는 유지해야 한다.
+- `SwitchGestureController`의 one-handed long press는 initial recognizer에서 keyboard stack recognizer로 이어질 수 있다. 두 recognizer의 취소 경로를 모두 처리하지 않으면 delegate 변경이 남는다.
+- overlay를 숨기기만 하고 강조, 버튼 상호작용, `isKeepGesturing`을 복구하지 않으면 키보드가 비활성 상태로 남을 수 있다.
+- UIKit interaction 테스트가 main actor와 recognizer 상태 전이에 민감할 수 있으므로 테스트 helper가 production 동작을 우회하지 않는지 확인해야 한다.
+- recognizer의 `cancelsTouchesInView`로 발생한 `.touchCancel`을 일반 터치 취소처럼 처리하면 `currentPressedButton.didSet`이 활성 recognizer를 취소해 반복 입력과 커서 드래그가 즉시 종료된다.
+
+## Verification
+
+집중 테스트:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/ButtonStateControllerTests \
+  -only-testing:SYKeyboardTests/TextInteractionGestureControllerTests \
+  -only-testing:SYKeyboardTests/SwitchGestureControllerTests
+```
+
+전체 테스트:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+키보드 extension 빌드:
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme HangeulKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme EnglishKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+수동 확인:
+
+- 실제 텍스트 입력 앱에서 문자/스페이스 짧은 팬을 취소한 뒤 문자가 입력되지 않고 다음 키가 정상 입력되는지 확인한다.
+- 삭제 드래그/길게 누르기를 취소한 뒤 반복 삭제가 멈추고 다음 입력이 정상 동작하는지 확인한다.
+- 문자/삭제 버튼을 길게 눌렀을 때 반복 입력이 계속되고, 버튼 영역 밖으로 드래그해도 커서 이동이 계속되는지 확인한다.
+- 키보드 선택 및 한 손 모드 overlay를 연 뒤 제스처를 취소했을 때 모드가 변경되지 않고 overlay와 버튼 상호작용이 정상 복구되는지 확인한다.
+- 같은 흐름을 정상 종료했을 때 기존 입력과 전환 결과가 유지되는지 확인한다.
+
+## Done Criteria
+
+- 취소/실패한 텍스트 팬이 입력 action을 실행하지 않는다.
+- 일반 터치의 `.touchCancel` 후 버튼/Shift/suggestion bar 상태가 정상 복구되고, 활성 제스처 중 `.touchCancel`은 반복 입력과 커서 드래그를 중단하지 않는다.
+- 취소/실패한 키보드 선택 및 한 손 모드 팬/long press가 delegate 변경을 확정하지 않는다.
+- 정상 `.ended` 동작과 stop/cleanup callback은 유지된다.
+- 관련 interaction 테스트, 전체 테스트, 한글/영문 extension 빌드 결과가 기록된다.
+- Track 2 findings 세 건이 처리 및 검증 결과와 함께 `Resolved` 또는 근거가 있는 다른 상태로 갱신된다.

--- a/dev/active/issue-65-common-keyboard-interaction-runtime/issue-65-common-keyboard-interaction-runtime-tasks.md
+++ b/dev/active/issue-65-common-keyboard-interaction-runtime/issue-65-common-keyboard-interaction-runtime-tasks.md
@@ -1,0 +1,48 @@
+# Issue 65 Common Keyboard Interaction Runtime Tasks
+
+Last Updated: 2026-06-14
+
+## Investigation And Scope
+
+- [x] GitHub issue #65 본문과 댓글을 확인한다.
+- [x] Track 2 findings 원본과 관련 controller/button/input action 코드를 대조한다.
+- [x] 세 finding이 현재 코드에서 성립하는지 평가한다.
+- [x] 전환 제스처의 initial/continuation long press를 포함한 수정 범위를 확정한다.
+- [x] 구현 시작 전 `git status --short`로 작업 범위를 다시 확인한다.
+
+## Tests First
+
+- [x] UIKit recognizer terminal 상태를 안정적으로 구동할 test double 또는 최소 internal helper 전략을 확정한다.
+- [x] `ButtonStateControllerTests`에 일반 버튼 `.touchCancel` 후 눌림/suggestion bar 복구와 다음 버튼 입력 횟수 검증을 추가한다.
+- [x] `ButtonStateControllerTests`에 Shift `.touchCancel` 후 `isShiftButtonPressed == false` 검증을 추가한다.
+- [x] 활성 제스처 중 일반 버튼/Shift `.touchCancel`이 제스처와 눌림 상태를 유지하는 회귀 테스트를 추가한다.
+- [x] 새 활성 제스처 `.touchCancel` 테스트가 첫 구현에서 실패하는지 확인한다.
+- [x] `TextInteractionGestureControllerTests`에 짧은 pan의 `.ended`만 입력하고 `.cancelled`/`.failed`는 입력하지 않는 검증을 추가한다.
+- [x] `TextInteractionGestureControllerTests`에 취소/실패 후 눌린 버튼, 사용자 상호작용, delete stop callback 정리 검증을 추가한다.
+- [x] `SwitchGestureControllerTests`에 keyboard select pan의 정상 종료/취소/실패별 delegate 횟수와 overlay 정리 검증을 추가한다.
+- [x] `SwitchGestureControllerTests`에 one-handed mode pan의 정상 종료/취소/실패별 delegate 횟수와 overlay 정리 검증을 추가한다.
+- [x] `SwitchGestureControllerTests`에 initial 및 continuation long press 취소 시 mode 변경 없이 overlay/상호작용이 복구되는 검증을 추가한다.
+- [x] 새 테스트가 현재 production 코드에서 의도대로 실패하는지 확인한다.
+
+## Implementation
+
+- [x] `TextInteractionGestureController`에서 `.ended`와 `.cancelled`/`.failed` 결과 확정 경로를 분리한다.
+- [x] 텍스트 pan 취소/실패 시 stale pressed state와 gesture/UI 상태를 정리하고 필요한 stop callback을 유지한다.
+- [x] `ButtonStateController`의 일반 버튼과 Shift 해제 이벤트에 `.touchCancel`을 추가한다.
+- [x] 활성 제스처 중 UIKit이 발생시킨 `.touchCancel`은 해제하지 않도록 일반 취소와 분리한다.
+- [x] `SwitchGestureController`의 두 pan handler에서 정상 종료만 `.touchUpInside`와 delegate 결과를 확정하도록 분리한다.
+- [x] `SwitchGestureController`의 initial/continuation long press에서 취소/실패가 delegate 결과를 확정하지 않도록 분리한다.
+- [x] 전환 제스처 취소 cleanup에서 overlay, 강조, 눌림, 상호작용, 내부 gesture 상태를 복구한다.
+
+## Verification And Documentation
+
+- [x] Track 2 집중 interaction 테스트를 실행한다.
+- [x] 전체 `SYKeyboard` 테스트를 실행한다.
+- [x] `HangeulKeyboard` scheme 빌드를 실행한다.
+- [x] `EnglishKeyboard` scheme 빌드를 실행한다.
+- [x] 조건부 `.touchCancel` 수정 후 집중 interaction 테스트를 다시 실행한다.
+- [ ] 조건부 `.touchCancel` 수정 후 전체 테스트와 한글/영문 extension 빌드를 다시 실행한다.
+- [x] 실기기에서 길게 누르기 반복 입력과 버튼 영역 밖 커서 드래그를 재확인한다.
+- [ ] 실제 입력 앱에서 취소/정상 종료 흐름을 수동 확인한다.
+- [x] `dev/active/code-review-scope/code-review-scope-findings.md`에 세 finding의 처리와 검증 결과를 반영한다.
+- [x] `git diff --check`와 `git status --short`로 문서/코드 변경 범위를 확인한다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #65
- 대상 리뷰 브랜치: #57 (`refactor/#57-overall-code-review`)

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 취소·실패한 텍스트 팬 제스처가 정상 키 입력을 실행하지 않도록 `.ended` 결과 확정 경로를 분리했습니다.
- 일반 `touchCancel`은 버튼·Shift 상태를 정리하되, 활성 제스처가 UIKit에 의해 받은 `touchCancel`은 유지해 길게 누르기 반복 입력과 커서 드래그가 중단되지 않도록 했습니다.
- 취소·실패한 키보드 선택 및 한 손 모드 제스처가 전환 결과를 확정하지 않고 overlay와 상호작용 상태만 정리하도록 변경했습니다.
- `ButtonStateControllerTests`, `TextInteractionGestureControllerTests`, `SwitchGestureControllerTests`를 추가해 정상 종료·취소·실패 상태 전이를 검증했습니다.
- Track 2의 P1/P1/P2 finding 세 건을 `Resolved`로 갱신하고 처리 내용과 검증 결과를 findings 문서에 반영했습니다.

<br>

## ✅ 검증
<!-- 실행한 빌드/테스트 명령과 결과를 작성해주세요. 실행하지 못했다면 이유를 적어주세요. -->
- 권한 있는 환경: issue #65 집중 interaction 테스트 `TEST SUCCEEDED`
  - `ButtonStateControllerTests`
  - `TextInteractionGestureControllerTests`
  - `SwitchGestureControllerTests`
- 권한 있는 환경: 전체 `SYKeyboard` 테스트 `TEST SUCCEEDED`
- 권한 있는 환경: `HangeulKeyboard`, `EnglishKeyboard` scheme 빌드 `BUILD SUCCEEDED`
- 사용자 실기기 확인: 길게 누르기 반복 입력과 버튼 영역 밖 커서 드래그 정상 동작 확인
- `git diff --check` 통과
- 일반 Codex 샌드박스 실행은 CoreSimulator 및 SwiftPM 캐시 권한 오류로 실패했으며, 위 테스트·빌드는 권한 있는 환경에서 재실행했습니다.

<!-- Codex 샌드박스 오류로 재실행한 경우 일반 실행 실패와 권한 있는 실행 결과를 구분해서 적어주세요. -->

<br>