### PR TITLE
Refactor/#69 키보드 확장 진입점 리뷰 반영

### DIFF
--- a/Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift
+++ b/Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift
@@ -67,7 +67,7 @@ private extension EnglishKeyboardViewController {
         ])
         
         let closeOverlayAction = UIAction { [weak self] _ in
-            self?.keyboardSettingsManager.isRequestFullAccessOverlayClosed = true
+            self?.keyboardExtensionLocalStateStore.isClosed = true
             self?.requestFullAccessOverlayView.isHidden = true
         }
         requestFullAccessOverlayView.closeButton.addAction(closeOverlayAction, for: .touchUpInside)

--- a/Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift
+++ b/Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift
@@ -67,7 +67,7 @@ private extension HangeulKeyboardViewController {
         ])
         
         let closeOverlayAction = UIAction { [weak self] _ in
-            self?.keyboardSettingsManager.isRequestFullAccessOverlayClosed = true
+            self?.keyboardExtensionLocalStateStore.isClosed = true
             self?.requestFullAccessOverlayView.isHidden = true
         }
         requestFullAccessOverlayView.closeButton.addAction(closeOverlayAction, for: .touchUpInside)

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -29,11 +29,13 @@ open class BaseKeyboardViewController: UIInputViewController {
 
     /// 전체 접근 허용 안내 필요 여부
     final public var needToShowFullAccessGuide: Bool {
-        return !hasFullAccess && !keyboardSettingsManager.isRequestFullAccessOverlayClosed
+        return !hasFullAccess && !keyboardExtensionLocalStateStore.isClosed
     }
 
     /// 키보드 설정을 관리하는 `UserDefaultsManager`
     final public let keyboardSettingsManager: UserDefaultsManager = UserDefaultsManager.shared
+    /// Keyboard extension별 local 상태 저장소
+    final public let keyboardExtensionLocalStateStore = KeyboardExtensionLocalStateStore()
 
     final public lazy var oldKeyboardType: UIKeyboardType? = textDocumentProxy.keyboardType
 

--- a/Modules/SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift
+++ b/Modules/SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift
@@ -1,0 +1,36 @@
+//
+//  KeyboardExtensionLocalStateStore.swift
+//  SYKeyboardCore
+//
+//  Created by Codex on 6/18/26.
+//
+
+import Foundation
+
+/// Keyboard extension별 local 상태 저장소
+final public class KeyboardExtensionLocalStateStore {
+
+    // MARK: - Properties
+
+    private let storage: UserDefaults
+    private let key: String
+
+    public var isClosed: Bool {
+        get {
+            storage.object(forKey: key) as? Bool ?? DefaultValues.isRequestFullAccessOverlayClosed
+        }
+        set {
+            storage.set(newValue, forKey: key)
+        }
+    }
+
+    // MARK: - Initializer
+
+    public init(
+        storage: UserDefaults = .standard,
+        key: String = UserDefaultsKeys.isRequestFullAccessOverlayClosed
+    ) {
+        self.storage = storage
+        self.key = key
+    }
+}

--- a/SYKeyboard.xcodeproj/project.pbxproj
+++ b/SYKeyboard.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 				SYKeyboardCore/Storage/DefaultValues.swift,
 				SYKeyboardCore/Storage/Enums/LongPressAction.swift,
 				SYKeyboardCore/Storage/Enums/OneHandedMode.swift,
+				SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift,
 				SYKeyboardCore/Storage/UserDefaultsKeys.swift,
 				SYKeyboardCore/Storage/UserDefaultsManager.swift,
 				SYKeyboardCore/SYKeyboardCore.docc,
@@ -377,6 +378,7 @@
 				SYKeyboardCore/Storage/DefaultValues.swift,
 				SYKeyboardCore/Storage/Enums/LongPressAction.swift,
 				SYKeyboardCore/Storage/Enums/OneHandedMode.swift,
+				SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift,
 				SYKeyboardCore/Storage/UserDefaultsKeys.swift,
 				SYKeyboardCore/Storage/UserDefaultsManager.swift,
 				SYKeyboardCore/SYKeyboardCore.docc,
@@ -1483,6 +1485,7 @@
 			baseConfigurationReferenceAnchor = 5B53F8012E1E56BD0083F7CA /* Keyboards */;
 			baseConfigurationReferenceRelativePath = "EnglishKeyboard/Resources/Configs/DebugConfig-EnglishKeyboard.xcconfig";
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyboards/EnglishKeyboard/Resources/EnglishKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(BUILD_NUMBER)";
@@ -1517,6 +1520,7 @@
 			baseConfigurationReferenceAnchor = 5B53F8012E1E56BD0083F7CA /* Keyboards */;
 			baseConfigurationReferenceRelativePath = "EnglishKeyboard/Resources/Configs/ReleaseConfig-EnglishKeyboard.xcconfig";
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyboards/EnglishKeyboard/Resources/EnglishKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(BUILD_NUMBER)";

--- a/SYKeyboardTests/Storage/UserDefaultsContractTests.swift
+++ b/SYKeyboardTests/Storage/UserDefaultsContractTests.swift
@@ -45,8 +45,8 @@ struct UserDefaultsContractTests {
         #expect(AppUserDefaultsKeys.lastBuildPromptedForReview == "lastBuildPromptedForReview")
     }
 
-    @Test("전체 접근 오버레이 닫힘 상태는 주입한 local 저장소에만 기록")
-    func testRequestFullAccessOverlayStateUsesLocalStorage() {
+    @Test("KeyboardExtensionLocalStateStore는 주입한 저장소에만 닫힘 상태를 기록")
+    func testKeyboardExtensionLocalStateStoreUsesInjectedStorage() {
         let suiteName = "RequestFullAccessOverlayStateTests-\(UUID().uuidString)"
         let localStorage = UserDefaults(suiteName: suiteName)!
         let sharedStorage = UserDefaultsManager.shared.storage

--- a/SYKeyboardTests/Storage/UserDefaultsContractTests.swift
+++ b/SYKeyboardTests/Storage/UserDefaultsContractTests.swift
@@ -44,6 +44,30 @@ struct UserDefaultsContractTests {
         #expect(AppUserDefaultsKeys.reviewCounter == "reviewCounter")
         #expect(AppUserDefaultsKeys.lastBuildPromptedForReview == "lastBuildPromptedForReview")
     }
+
+    @Test("전체 접근 오버레이 닫힘 상태는 주입한 local 저장소에만 기록")
+    func testRequestFullAccessOverlayStateUsesLocalStorage() {
+        let suiteName = "RequestFullAccessOverlayStateTests-\(UUID().uuidString)"
+        let localStorage = UserDefaults(suiteName: suiteName)!
+        let sharedStorage = UserDefaultsManager.shared.storage
+        let key = UserDefaultsKeys.isRequestFullAccessOverlayClosed
+        let originalSharedValue = sharedStorage.object(forKey: key)
+
+        sharedStorage.removeObject(forKey: key)
+        defer {
+            localStorage.removePersistentDomain(forName: suiteName)
+            restore(originalSharedValue, forKey: key, in: sharedStorage)
+        }
+
+        let store = KeyboardExtensionLocalStateStore(storage: localStorage)
+
+        #expect(store.isClosed == DefaultValues.isRequestFullAccessOverlayClosed)
+
+        store.isClosed = true
+
+        #expect(localStorage.bool(forKey: key) == true)
+        #expect(sharedStorage.object(forKey: key) == nil)
+    }
 }
 
 private extension UserDefaultsContractTests {

--- a/dev/active/code-review-scope/code-review-scope-findings.md
+++ b/dev/active/code-review-scope/code-review-scope-findings.md
@@ -1,6 +1,6 @@
 # Code Review Scope Findings
 
-Last Updated: 2026-06-18
+Last Updated: 2026-06-19
 
 ## Purpose
 
@@ -232,21 +232,28 @@ Last Updated: 2026-06-18
 
 ### Track 6. Keyboard Extension Entry Points
 
-#### [P2][Open] 전체 접근 미허용 상태에서 오버레이 닫힘 상태를 공유 컨테이너에 저장함
+#### [P2][Resolved] 전체 접근 미허용 상태에서 오버레이 닫힘 상태를 공유 컨테이너에 저장함
 
-- 위치: `Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift:70`, `Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift:70`, `Modules/SYKeyboardCore/Storage/UserDefaultsManager.swift:180`
+- 위치: `Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift:70`, `Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift:70`, `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift:31`, `Modules/SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift`
 - 영향: 전체 접근을 허용하지 않은 사용자가 안내를 닫아도 keyboard extension이 app-group 공유 컨테이너에 접근할 수 없어 닫힘 상태가 다음 세션에 유지되지 않을 수 있다. 그 결과 한글/영문 키보드를 다시 열 때 전체 화면 오버레이가 반복 표시될 수 있다.
 - 근거: 오버레이는 `hasFullAccess == false`일 때 표시되지만 닫기 action은 app-group suite를 사용하는 `keyboardSettingsManager.isRequestFullAccessOverlayClosed`에 기록한다.
-- 결정: 닫힘 상태는 각 keyboard extension의 `UserDefaults.standard`에 기록한다. 한글/영문 extension은 닫힘 상태를 서로 독립적으로 유지하며, app-group 저장소와 동기화하거나 전체 접근 허용 후 마이그레이션하지 않는다.
-- 검증: 독립 코드리뷰와 코드 경로 확인. 수정 후 전체 접근 미허용 상태에서 한글/영문 키보드 각각 오버레이를 닫고 extension을 종료/재실행해 상태가 독립적으로 유지되는지 확인한다.
+- 처리: `KeyboardExtensionLocalStateStore`를 추가해 기본 저장소를 `UserDefaults.standard`로 분리했다. `BaseKeyboardViewController.needToShowFullAccessGuide`와 한글/영문 overlay close action이 이 local store를 사용하도록 변경했다. app-group 저장소와 동기화하거나 전체 접근 허용 후 migration하지 않는다.
+- 검증:
+  - 구현 전 `UserDefaultsContractTests/testRequestFullAccessOverlayStateUsesLocalStorage()`는 local state store 타입 미정의로 실패하는 것을 확인했다.
+  - rename 작업에서 테스트를 먼저 `KeyboardExtensionLocalStateStore`로 변경한 뒤, 권한 있는 환경에서 타입 미정의 compile error로 RED를 확인했다.
+  - 구현 후 권한 있는 환경의 `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/UserDefaultsContractTests`에서 `TEST SUCCEEDED`를 확인했다.
+  - 권한 있는 환경의 전체 `SYKeyboard` 테스트와 `HangeulKeyboard`, `EnglishKeyboard` scheme 빌드가 모두 성공했다.
+  - 2026-06-19 사용자 실기기 확인에서 전체 접근 미허용 상태의 한글/영문 오버레이 닫힘 유지 동작이 정상이라고 확인했다.
 
-#### [P2][Open] EnglishKeyboard target에 app-extension-safe API 검사가 비활성화되어 있음
+#### [P2][Resolved] EnglishKeyboard target에 app-extension-safe API 검사가 비활성화되어 있음
 
-- 위치: `SYKeyboard.xcodeproj/project.pbxproj:1477`, `SYKeyboard.xcodeproj/project.pbxproj:1511`
+- 위치: `SYKeyboard.xcodeproj/project.pbxproj`
 - 영향: 영어 keyboard extension 또는 의존 코드에 app extension에서 사용할 수 없는 API가 추가되어도 빌드 시 검출되지 않을 수 있다. 같은 역할의 한글 extension과 안전성 검증 수준도 달라진다.
 - 근거: HangeulKeyboard Debug/Release에는 `APPLICATION_EXTENSION_API_ONLY = YES`가 있지만 EnglishKeyboard Debug/Release에는 해당 설정이 없다.
-- 결정: EnglishKeyboard Debug/Release에도 `APPLICATION_EXTENSION_API_ONLY = YES`를 적용한다. 변경 후 extension target만 대상으로 빌드해 현재 의존성까지 app-extension-safe인지 확인한다.
-- 검증: 일반 EnglishKeyboard scheme 빌드는 통과했다. 명령행에서 설정을 전역 override하면 host app에도 적용되어 `UIApplication.shared`에서 실패했고, target 단독 override 검증은 DerivedData 내부 충돌로 완료하지 못했다.
+- 처리: EnglishKeyboard Debug/Release build settings에 `APPLICATION_EXTENSION_API_ONLY = YES`를 추가했다.
+- 검증:
+  - 권한 있는 환경의 `xcodebuild build -project SYKeyboard.xcodeproj -scheme EnglishKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`에서 `BUILD SUCCEEDED`를 확인했다.
+  - 권한 있는 환경의 `HangeulKeyboard` scheme 빌드와 전체 `SYKeyboard` 테스트도 성공했다.
 
 #### [P3][Deferred] 설정 이동 버튼이 URL 열기 실패를 조용히 무시함
 
@@ -374,4 +381,4 @@ Last Updated: 2026-06-18
 - Track 8의 앱 번들 문서/스크립트 포함과 중복 `DeveloperEmail` findings는 사용자 수정 후 빌드 산출물 검증을 거쳐 `Resolved` 처리했다.
 - Meta mediation package는 전이 의존성이 아니라 프로젝트에 직접 추가된 의존성이다. release version 기반 requirement로 다시 추가하고 빌드를 검증해 mutable `main` branch finding을 `Resolved` 처리했다.
 - `SYKeyboardAssets` resource bundle에는 ignored `.DS_Store`가 포함되지 않아 추가 finding으로 보지 않는다.
-- Track 6의 EnglishKeyboard `APPLICATION_EXTENSION_API_ONLY` parity finding은 여전히 Open이며, Track 8에서 중복 finding을 추가하지 않았다.
+- Track 6의 EnglishKeyboard `APPLICATION_EXTENSION_API_ONLY` parity finding은 `Resolved` 처리했고, Track 8에서 중복 finding을 추가하지 않았다.

--- a/dev/active/issue-69-keyboard-entry-points/issue-69-keyboard-entry-points-context.md
+++ b/dev/active/issue-69-keyboard-entry-points/issue-69-keyboard-entry-points-context.md
@@ -1,0 +1,126 @@
+# Issue 69 Keyboard Entry Points Context
+
+Last Updated: 2026-06-19
+
+## Relevant Files
+
+- `dev/active/code-review-scope/code-review-scope-findings.md`: Track 6 findings 원문과 현재 상태.
+- `Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift`: 한글 keyboard extension entry point. 전체 접근 오버레이 표시와 닫기 action을 갖는다.
+- `Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift`: 영어 keyboard extension entry point. 한글과 동일한 전체 접근 오버레이 표시와 닫기 action을 갖는다.
+- `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift`: `needToShowFullAccessGuide`가 `hasFullAccess`와 shared `UserDefaultsManager` 값을 함께 본다.
+- `Modules/SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift`: keyboard extension별 local 상태를 `UserDefaults.standard`에 저장하는 새 저장소.
+- `Modules/SYKeyboardCore/Storage/UserDefaultsManager.swift`: `UserDefaults(suiteName: DefaultValues.groupBundleID)` 기반 app-group 저장소를 사용한다.
+- `Modules/SYKeyboardCore/Storage/UserDefaultsKeys.swift`: `isRequestFullAccessOverlayClosed` key 문자열을 정의한다.
+- `Modules/SYKeyboardCore/Storage/DefaultValues.swift`: `isRequestFullAccessOverlayClosed` 기본값을 `false`로 정의한다.
+- `SYKeyboard.xcodeproj/project.pbxproj`: Hangeul/English extension target build settings를 정의한다.
+
+## Facts Checked
+
+- GitHub Issue #69의 본문을 `gh api repos/SNMac/SYKeyboard/issues/69`로 확인했다.
+- Issue #69 댓글 API는 빈 배열이었다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`의 Track 6에는 두 P2 항목이 `Open` 상태로 남아 있다.
+- `HangeulKeyboardViewController.swift:38`과 `EnglishKeyboardViewController.swift:38`은 `needToShowFullAccessGuide`가 참이면 오버레이를 추가한다.
+- `HangeulKeyboardViewController.swift:70`과 `EnglishKeyboardViewController.swift:70`은 닫기 action에서 `keyboardSettingsManager.isRequestFullAccessOverlayClosed = true`를 기록한다.
+- `BaseKeyboardViewController.swift:31-32`는 `!hasFullAccess && !keyboardSettingsManager.isRequestFullAccessOverlayClosed`로 오버레이 표시 필요 여부를 계산한다.
+- `UserDefaultsManager.swift:19-24`, `UserDefaultsManager.swift:87-88`은 app-group suiteName 기반 `UserDefaults`를 사용한다.
+- `UserDefaultsManager.swift:180-181`은 `isRequestFullAccessOverlayClosed`를 shared manager property로 제공한다.
+- `SYKeyboard.xcodeproj/project.pbxproj:1418`, `SYKeyboard.xcodeproj/project.pbxproj:1452`에는 HangeulKeyboard Debug/Release의 `APPLICATION_EXTENSION_API_ONLY = YES`가 있다.
+- `SYKeyboard.xcodeproj/project.pbxproj:1485-1511`, `SYKeyboard.xcodeproj/project.pbxproj:1519-1545`에는 EnglishKeyboard Debug/Release의 `APPLICATION_EXTENSION_API_ONLY` 설정이 없다.
+- `Keyboards/HangeulKeyboard/Resources/HangeulKeyboard.entitlements`와 `Keyboards/EnglishKeyboard/Resources/EnglishKeyboard.entitlements`는 둘 다 같은 app group을 선언한다.
+- `KeyboardExtensionLocalStateStore`는 기본 저장소로 `UserDefaults.standard`를 사용하고, 테스트에서는 별도 suite를 주입할 수 있다.
+- `BaseKeyboardViewController.needToShowFullAccessGuide`는 이제 shared `UserDefaultsManager`가 아니라 `keyboardExtensionLocalStateStore.isClosed`를 본다.
+- 한글/영문 overlay close action은 이제 `keyboardExtensionLocalStateStore.isClosed = true`를 기록한다.
+- EnglishKeyboard Debug/Release build settings에 `APPLICATION_EXTENSION_API_ONLY = YES`를 추가했다.
+- 오버레이 전용 local store 이름은 확장별 local 상태가 늘어날 가능성을 반영해 `KeyboardExtensionLocalStateStore`로 변경했다.
+
+## Decisions
+
+- 두 P2 finding은 현재 코드 기준으로 타당하다.
+- 오버레이 닫힘 상태는 app-group 저장소가 아니라 각 extension의 `UserDefaults.standard`에 저장한다.
+- 한글/영문 오버레이 닫힘 상태는 서로 독립적으로 유지한다.
+- app-group 저장소와 extension-local 저장소 사이 migration은 하지 않는다.
+- EnglishKeyboard target도 HangeulKeyboard target과 동일하게 `APPLICATION_EXTENSION_API_ONLY = YES`를 적용한다.
+- local state store 타입은 오버레이 전용 이름이 아니라 keyboard extension별 local 상태를 담을 수 있는 `KeyboardExtensionLocalStateStore`를 사용한다.
+
+## Open Questions
+
+- 현재 없음.
+
+## Verification Notes
+
+- 실행함:
+
+```sh
+git status --short
+```
+
+결과: 출력 없음. 작업 전 tracked/untracked 변경 없음.
+
+- 실행함:
+
+```sh
+gh issue view 69 --repo SNMac/SYKeyboard --comments
+```
+
+결과: 샌드박스 네트워크 제한으로 실패.
+
+- 실행함:
+
+```sh
+gh api repos/SNMac/SYKeyboard/issues/69
+gh api repos/SNMac/SYKeyboard/issues/69/comments
+```
+
+결과: 권한 있는 실행에서 이슈 본문 확인 성공. 댓글은 빈 배열.
+
+- 실행함:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/UserDefaultsContractTests
+```
+
+결과:
+- 일반 샌드박스: CoreSimulatorService, ModuleCache, SwiftPM ManifestLoading 권한 오류로 실패.
+- 권한 있는 실행, 구현 전: local state store 타입 미정의로 실패해 RED 확인.
+- 권한 있는 실행, 구현 후 target membership 추가 전: Core target에서 같은 타입 미정의로 실패.
+- 권한 있는 실행, target membership 추가 후: `TEST SUCCEEDED`.
+- rename 작업 중 테스트를 먼저 `KeyboardExtensionLocalStateStore`로 변경한 뒤, 권한 있는 실행에서 `cannot find 'KeyboardExtensionLocalStateStore' in scope` compile error로 RED를 확인했다.
+- rename 적용 후 같은 focused 테스트를 권한 있는 실행에서 재실행해 `TEST SUCCEEDED`를 확인했다.
+
+- 실행함:
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme HangeulKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 권한 있는 실행에서 `BUILD SUCCEEDED`.
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme EnglishKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 권한 있는 실행에서 `BUILD SUCCEEDED`.
+
+- 실행함:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 권한 있는 실행에서 `TEST SUCCEEDED`.
+
+- 수동 검증:
+  - 2026-06-19 사용자 실기기 확인에서 전체 접근 미허용 상태의 한글/영문 오버레이 닫힘 유지 동작이 정상이라고 확인했다.

--- a/dev/active/issue-69-keyboard-entry-points/issue-69-keyboard-entry-points-plan.md
+++ b/dev/active/issue-69-keyboard-entry-points/issue-69-keyboard-entry-points-plan.md
@@ -1,0 +1,119 @@
+# Issue 69 Keyboard Entry Points Plan
+
+Last Updated: 2026-06-19
+
+## Goal
+
+- GitHub Issue #69의 Track 6 `Keyboard Extension Entry Points` findings가 현재 코드에서 타당한지 판단하고, 타당한 항목의 수정 계획과 검증 기준을 정한다.
+
+## Current State
+
+- 관련 이슈: `https://github.com/SNMac/SYKeyboard/issues/69`
+- 관련 findings 문서: `dev/active/code-review-scope/code-review-scope-findings.md`
+- 처리한 finding:
+  - `[P2] 전체 접근 미허용 상태에서 오버레이 닫힘 상태를 공유 컨테이너에 저장함`
+  - `[P2] EnglishKeyboard target에 app-extension-safe API 검사가 비활성화되어 있음`
+- 관련 파일:
+  - `Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift`
+  - `Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift`
+  - `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift`
+  - `Modules/SYKeyboardCore/Storage/UserDefaultsManager.swift`
+  - `Modules/SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift`
+  - `Modules/SYKeyboardCore/Storage/UserDefaultsKeys.swift`
+  - `Modules/SYKeyboardCore/Storage/DefaultValues.swift`
+  - `SYKeyboard.xcodeproj/project.pbxproj`
+
+## Review Evaluation
+
+### Finding 1: 전체 접근 미허용 상태에서 오버레이 닫힘 상태를 공유 컨테이너에 저장함
+
+- 판단: 타당함.
+- 근거:
+  - `BaseKeyboardViewController.needToShowFullAccessGuide`는 `!hasFullAccess && !keyboardSettingsManager.isRequestFullAccessOverlayClosed`를 사용한다.
+  - 한글/영문 close action은 모두 `keyboardSettingsManager.isRequestFullAccessOverlayClosed = true`를 호출한다.
+  - `UserDefaultsManager`와 `UserDefaultsWrapper`는 `UserDefaults(suiteName: DefaultValues.groupBundleID)` 기반 app-group 저장소를 사용한다.
+  - keyboard extension의 전체 접근 미허용 상태에서는 app-group 공유 컨테이너 접근이 제한될 수 있으므로, 닫힘 상태가 다음 extension 세션에 유지되지 않을 위험이 있다.
+- 결정: 닫힘 상태는 각 keyboard extension의 `UserDefaults.standard`에 저장한다. 한글/영문은 독립 상태를 유지한다. app-group 값과 동기화하거나 migration하지 않는다.
+
+### Finding 2: EnglishKeyboard target에 app-extension-safe API 검사가 비활성화되어 있음
+
+- 판단: 타당함.
+- 근거:
+  - `SYKeyboard.xcodeproj/project.pbxproj`의 `HangeulKeyboard` Debug/Release에는 `APPLICATION_EXTENSION_API_ONLY = YES`가 있다.
+  - 같은 역할의 `EnglishKeyboard` Debug/Release에는 해당 설정이 없다.
+  - 이 차이는 영어 extension에 app-extension-safe API 검사가 빠지는 구성 불일치다.
+- 결정: `EnglishKeyboard` Debug/Release build settings에 `APPLICATION_EXTENSION_API_ONLY = YES`를 추가한다.
+
+## Approach
+
+1. 오버레이 닫힘 상태 저장소를 extension-local로 분리했다.
+   - `Modules/SYKeyboardCore/Storage/KeyboardExtensionLocalStateStore.swift`를 추가하고 기본 저장소를 `UserDefaults.standard`로 뒀다.
+   - 테스트에서는 별도 suite를 주입해 shared app-group 저장소에 쓰지 않는 계약을 검증했다.
+   - `needToShowFullAccessGuide`와 한글/영문 close action은 local store를 사용한다.
+2. EnglishKeyboard target build settings를 한글 target과 맞췄다.
+   - Debug/Release 양쪽에 `APPLICATION_EXTENSION_API_ONLY = YES`를 추가했다.
+3. 문서 상태를 갱신했다.
+   - `dev/active/code-review-scope/code-review-scope-findings.md`의 두 항목을 `Resolved`로 변경하고 처리/검증 결과를 기록했다.
+   - 이 작업 문서의 tasks/context도 실제 결과로 갱신했다.
+
+## Risks
+
+- 오버레이 표시 여부는 extension entry point에서 결정되므로 실제 키보드 extension lifecycle과 전체 접근 미허용 상태에서 수동 확인이 필요하다.
+- `APPLICATION_EXTENSION_API_ONLY = YES` 추가 후 EnglishKeyboard 빌드가 app-extension-unsafe API 사용을 새로 드러낼 수 있다. 이 경우 build setting만 추가하고 끝내지 말고, 실제 unsafe API 사용 여부를 별도 판단한다.
+- `Keyboards/Common`에 새 파일을 추가할 경우 target membership이 의도대로 한글/영문 extension에만 적용되는지 확인해야 한다.
+
+## Verification
+
+- 실행한 자동 검증:
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme HangeulKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme EnglishKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- 추가 실행:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/UserDefaultsContractTests
+```
+
+- 결과:
+  - 일반 샌드박스의 focused 테스트는 Xcode/SwiftPM/CoreSimulator 캐시 권한 오류로 실패했다.
+  - rename 작업에서 테스트를 먼저 `KeyboardExtensionLocalStateStore`로 바꾼 뒤, 권한 있는 환경에서 local state store 타입 미정의 compile error로 RED를 확인했다.
+  - 권한 있는 환경의 focused `UserDefaultsContractTests`는 `TEST SUCCEEDED`.
+  - 권한 있는 환경의 `HangeulKeyboard` build는 `BUILD SUCCEEDED`.
+  - 권한 있는 환경의 `EnglishKeyboard` build는 `BUILD SUCCEEDED`.
+  - 권한 있는 환경의 전체 `SYKeyboard` test는 `TEST SUCCEEDED`.
+
+- 수동 확인:
+  - 전체 접근 미허용 상태에서 한글 키보드 오버레이를 닫고 extension을 종료/재실행했을 때 닫힘 상태가 유지된다.
+  - 전체 접근 미허용 상태에서 영어 키보드 오버레이를 닫고 extension을 종료/재실행했을 때 닫힘 상태가 유지된다.
+  - 한글에서 닫아도 영어의 닫힘 상태가 자동으로 닫히지 않고, 영어에서 닫아도 한글의 닫힘 상태가 자동으로 닫히지 않는다.
+  - 2026-06-19 사용자 실기기 확인에서 정상 동작을 확인했다.
+
+## Done Criteria
+
+- 두 P2 finding의 코드 수정이 적용되었다.
+- `HangeulKeyboard`, `EnglishKeyboard` scheme 빌드 결과가 기록되었다.
+- 전체 접근 미허용 상태의 오버레이 닫힘 유지 동작은 사용자 실기기 확인 결과를 기록했다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`와 이 작업 문서가 실제 처리 상태를 반영한다.

--- a/dev/active/issue-69-keyboard-entry-points/issue-69-keyboard-entry-points-tasks.md
+++ b/dev/active/issue-69-keyboard-entry-points/issue-69-keyboard-entry-points-tasks.md
@@ -1,0 +1,21 @@
+# Issue 69 Keyboard Entry Points Tasks
+
+Last Updated: 2026-06-19
+
+## Checklist
+
+- [x] Issue #69 본문과 댓글을 확인한다.
+- [x] `dev/README.md`, `dev/templates/*`, `dev/codex-skill-playbook.md`, `dev/coding-conventions.md`의 관련 지침을 확인한다.
+- [x] Track 6 findings 문서와 관련 코드 위치를 읽는다.
+- [x] 각 리뷰 사항이 현재 코드 기준으로 타당한지 판단한다.
+- [x] 수정 방향, 위험, 검증 기준을 작업 문서에 기록한다.
+- [x] 오버레이 닫힘 상태를 extension-local `UserDefaults.standard` 저장으로 변경한다.
+- [x] 한글/영문 오버레이 닫힘 상태가 독립적으로 유지되도록 구현한다.
+- [x] EnglishKeyboard Debug/Release target에 `APPLICATION_EXTENSION_API_ONLY = YES`를 추가한다.
+- [x] 가능한 경우 오버레이 상태 저장 helper의 단위 테스트를 추가하거나, 테스트가 부적합한 이유를 기록한다.
+- [x] `HangeulKeyboard` scheme 빌드를 실행한다.
+- [x] `EnglishKeyboard` scheme 빌드를 실행한다.
+- [x] 전체 접근 미허용 상태에서 한글/영문 키보드 오버레이 닫힘 유지 동작을 수동 확인한다.
+- [x] `dev/active/code-review-scope/code-review-scope-findings.md`의 Track 6 상태와 검증 결과를 갱신한다.
+- [x] `git status --short`로 의도하지 않은 변경이 없는지 확인한다.
+- [x] 완료 내용과 검증 결과를 최종 응답에 요약한다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #69

<br>

## 📝 작업 내용
- 전체 접근 미허용 상태에서 오버레이 닫힘 상태를 app-group `UserDefaultsManager`가 아니라 extension-local `UserDefaults.standard`에 저장하도록 `KeyboardExtensionLocalStateStore`를 추가했습니다.
- 한글/영어 키보드 오버레이 close action과 `BaseKeyboardViewController.needToShowFullAccessGuide`가 local store를 사용하도록 변경했습니다.
- `EnglishKeyboard` Debug/Release target에 `APPLICATION_EXTENSION_API_ONLY = YES`를 추가해 한글 extension과 app-extension-safe API 검사 수준을 맞췄습니다.
- local 저장소 계약 테스트와 issue #69 Track 6 작업 문서를 추가/갱신했습니다.

<br>

## ✅ 검증
- `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/UserDefaultsContractTests` → `TEST SUCCEEDED`
- `xcodebuild build -project SYKeyboard.xcodeproj -scheme HangeulKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` → `BUILD SUCCEEDED`
- `xcodebuild build -project SYKeyboard.xcodeproj -scheme EnglishKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` → `BUILD SUCCEEDED`
- `git diff --cached --check` → 통과
- 일반 Codex 샌드박스에서는 Xcode/CoreSimulator/캐시 권한 제한이 있어 Xcode 명령은 권한 있는 실행으로 검증했습니다.
- 2026-06-19 사용자 실기기 확인에서 전체 접근 미허용 상태의 한글/영문 오버레이 닫힘 유지 동작이 정상이라고 확인했습니다.

<br>
