### PR TITLE
Fix/#70 메인 앱 리뷰와 권한 요청 흐름 보정

### DIFF
--- a/SYKeyboard/App/AppTrackingAuthorizationPolicy.swift
+++ b/SYKeyboard/App/AppTrackingAuthorizationPolicy.swift
@@ -1,0 +1,36 @@
+//
+//  AppTrackingAuthorizationPolicy.swift
+//  SYKeyboard
+//
+//  Created by Codex on 6/19/26.
+//
+
+enum AppTrackingAuthorizationPolicy {
+    
+    // MARK: - Nested Types
+    
+    struct Result {
+        let shouldRequestAuthorization: Bool
+        let shouldClearSettingsRedirect: Bool
+    }
+    
+    // MARK: - Internal Methods
+    
+    static func evaluateDidBecomeActive(isTrackingAuthorizationNotDetermined: Bool,
+                                        isOnboarding: Bool,
+                                        isHandlingSettingsRedirect: Bool) -> Result {
+        if isHandlingSettingsRedirect {
+            return Result(shouldRequestAuthorization: false,
+                          shouldClearSettingsRedirect: true)
+        }
+        
+        return Result(shouldRequestAuthorization: isTrackingAuthorizationNotDetermined && !isOnboarding,
+                      shouldClearSettingsRedirect: false)
+    }
+    
+    static func evaluateOnboardingDismissed(isTrackingAuthorizationNotDetermined: Bool,
+                                            isHandlingSettingsRedirect: Bool) -> Result {
+        Result(shouldRequestAuthorization: isTrackingAuthorizationNotDetermined && !isHandlingSettingsRedirect,
+               shouldClearSettingsRedirect: false)
+    }
+}

--- a/SYKeyboard/App/SYKeyboardApp.swift
+++ b/SYKeyboard/App/SYKeyboardApp.swift
@@ -17,29 +17,29 @@ import GoogleMobileAds
 import SYKeyboardCore
 
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+
     // MARK: - Properties
-    
+
     private lazy var logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "Unknown Bundle",
         category: "\(String(describing: type(of: self))) <\(Unmanaged.passUnretained(self).toOpaque())>"
     )
-    
+
     var window: UIWindow?  // FBAudienceNetwork 크래시 방지
-    
+
     // MARK: - didFinishLaunchingWithOptions
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Firebase 로딩
         FirebaseApp.configure()
-        
+
         // IDFV를 사용하여 Analytics, Crashlytics User ID 설정
         let idfv = UIDevice.current.identifierForVendor?.uuidString
         Analytics.setUserID(idfv)
         Crashlytics.crashlytics().setUserID(idfv)
-        
+
         setInitialUserProperties()
-        
+
         // AdMob 로딩
         Task {
             let initializationStatus = await MobileAds.shared.start()
@@ -47,37 +47,37 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
                 logger.debug("Adapter: \(adapterName), Description: \(status.description), Latency: \(status.latency)")
             }
         }
-        
+
         return true
     }
-    
+
     // MARK: - Helper Methods
-    
+
     /// 앱 실행 시 현재 `UserDefaults`에 저장된 설정값들을 Firebase Analytics User Property로 전송합니다.
     private func setInitialUserProperties() {
         let keyboardSettingsManager = UserDefaultsManager.shared
-        
+
         func setAnalyticsProperty(_ string: String, forName name: String) {
             Analytics.setUserProperty(string, forName: name)
         }
-        
+
         func setAnalyticsProperty(_ bool: Bool, forName name: String) {
             Analytics.setUserProperty(bool.analyticsValue, forName: name)
         }
-        
+
         func setAnalyticsProperty(_ double: Double, format: String, forName name: String) {
             Analytics.setUserProperty(String(format: format, double), forName: name)
         }
-        
+
         // 한글 키보드
         let selectedHangeulKeyboardRaw = keyboardSettingsManager.selectedHangeulKeyboard.rawValue
         let hangeulKeyboard = HangeulKeyboardSelectView.HangeulKeyboard(rawValue: selectedHangeulKeyboardRaw) ?? .naratgeul
         setAnalyticsProperty(hangeulKeyboard.analyticsValue, forName: "pref_hangeul_keyboard")
-        
+
         // 피드백 설정
         setAnalyticsProperty(keyboardSettingsManager.isSoundFeedbackEnabled, forName: "pref_sound_feedback")
         setAnalyticsProperty(keyboardSettingsManager.isHapticFeedbackEnabled, forName: "pref_haptic_feedback")
-        
+
         // 입력 설정
         let selectedLongPressActionRaw = keyboardSettingsManager.selectedLongPressAction.rawValue
         let longPressMode = InputSettingsView.LongPressMode(rawValue: selectedLongPressActionRaw) ?? .repeatInput
@@ -91,13 +91,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         setAnalyticsProperty(keyboardSettingsManager.isDragToMoveCursorEnabled, forName: "pref_drag_to_move_cursor")
         setAnalyticsProperty(keyboardSettingsManager.cursorActiveDistance, format: "%.1f", forName: "pref_cursor_atv_distance")
         setAnalyticsProperty(keyboardSettingsManager.cursorMoveInterval, format: "%.1f", forName: "pref_cursor_mv_interval")
-        
+
         // 외형 설정
         setAnalyticsProperty(keyboardSettingsManager.keyboardHeight, format: "%.1f", forName: "pref_keyboard_height")
         setAnalyticsProperty(keyboardSettingsManager.isNumericKeypadEnabled, forName: "pref_numeric_keypad")
         setAnalyticsProperty(keyboardSettingsManager.isOneHandedKeyboardEnabled, forName: "pref_one_handed_keyboard")
         setAnalyticsProperty(keyboardSettingsManager.oneHandedKeyboardWidth, format: "%.1f", forName: "pref_one_handed_width")
-        
+
         logger.debug("Firebase Analytics User Properties 초기화 완료")
     }
 }
@@ -106,25 +106,53 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
 @main
 struct SYKeyboardApp: App {
-    
+
     // MARK: - Properties
-    
+
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     @Environment(\.openURL) var openURL
-    
+
+    @AppStorage(AppUserDefaultsKeys.isOnboarding, store: AppUserDefaultsManager.shared.storage)
+    private var isOnboarding = AppDefaultValues.isOnboarding
+
+    @State private var isHandlingSettingsRedirect = false
+
     // MARK: - Content
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .onOpenURL { url in
+                    isHandlingSettingsRedirect = true
                     if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
                         openURL(settingsURL)
                     }
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-                    if ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+                    let result = AppTrackingAuthorizationPolicy.evaluateDidBecomeActive(
+                        isTrackingAuthorizationNotDetermined: ATTrackingManager.trackingAuthorizationStatus == .notDetermined,
+                        isOnboarding: isOnboarding,
+                        isHandlingSettingsRedirect: isHandlingSettingsRedirect
+                    )
+
+                    if result.shouldClearSettingsRedirect {
+                        isHandlingSettingsRedirect = false
+                    }
+
+                    if result.shouldRequestAuthorization {
+                        Task { await ATTrackingManager.requestTrackingAuthorization() }
+                    }
+                }
+                .onChange(of: isOnboarding) { newValue in
+                    guard newValue == false else { return }
+
+                    let result = AppTrackingAuthorizationPolicy.evaluateOnboardingDismissed(
+                        isTrackingAuthorizationNotDetermined: ATTrackingManager.trackingAuthorizationStatus == .notDetermined,
+                        isHandlingSettingsRedirect: isHandlingSettingsRedirect
+                    )
+
+                    if result.shouldRequestAuthorization {
                         Task { await ATTrackingManager.requestTrackingAuthorization() }
                     }
                 }

--- a/SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewPolicy.swift
+++ b/SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewPolicy.swift
@@ -1,0 +1,73 @@
+//
+//  RequestReviewPolicy.swift
+//  SYKeyboard
+//
+//  Created by Codex on 6/19/26.
+//
+
+enum RequestReviewPolicy {
+    
+    // MARK: - Nested Types
+    
+    struct Result {
+        let reviewCounter: Int
+        let lastBuildPromptedForReview: String
+        let shouldRequestReview: Bool
+    }
+    
+    // MARK: - Properties
+    
+    static let threshold = 5
+    
+    // MARK: - Internal Methods
+    
+    static func recordEligibleInteraction(reviewCounter: Int,
+                                          lastBuildPromptedForReview: String = "",
+                                          isEligible: Bool) -> Result {
+        guard isEligible else {
+            return Result(reviewCounter: reviewCounter,
+                          lastBuildPromptedForReview: lastBuildPromptedForReview,
+                          shouldRequestReview: false)
+        }
+        
+        return Result(reviewCounter: reviewCounter + 1,
+                      lastBuildPromptedForReview: lastBuildPromptedForReview,
+                      shouldRequestReview: false)
+    }
+    
+    static func evaluateDetailSettingsReturn(reviewCounter: Int,
+                                             currentAppBuild: String?,
+                                             lastBuildPromptedForReview: String,
+                                             isEligible: Bool) -> Result {
+        guard isEligible,
+              let currentAppBuild,
+              reviewCounter >= threshold,
+              currentAppBuild != lastBuildPromptedForReview else {
+            return Result(reviewCounter: reviewCounter,
+                          lastBuildPromptedForReview: lastBuildPromptedForReview,
+                          shouldRequestReview: false)
+        }
+        
+        return Result(reviewCounter: 0,
+                      lastBuildPromptedForReview: currentAppBuild,
+                      shouldRequestReview: true)
+    }
+    
+    static func recordDetailSettingsReturnAndEvaluate(reviewCounter: Int,
+                                                      currentAppBuild: String?,
+                                                      lastBuildPromptedForReview: String,
+                                                      isEligible: Bool) -> Result {
+        let recordResult = recordEligibleInteraction(
+            reviewCounter: reviewCounter,
+            lastBuildPromptedForReview: lastBuildPromptedForReview,
+            isEligible: isEligible
+        )
+        
+        return evaluateDetailSettingsReturn(
+            reviewCounter: recordResult.reviewCounter,
+            currentAppBuild: currentAppBuild,
+            lastBuildPromptedForReview: recordResult.lastBuildPromptedForReview,
+            isEligible: isEligible
+        )
+    }
+}

--- a/SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewPolicy.swift
+++ b/SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewPolicy.swift
@@ -17,7 +17,7 @@ enum RequestReviewPolicy {
     
     // MARK: - Properties
     
-    static let threshold = 5
+    static let threshold = 30
     
     // MARK: - Internal Methods
     

--- a/SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewViewModifier.swift
+++ b/SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewViewModifier.swift
@@ -10,37 +10,41 @@ import OSLog
 import StoreKit
 
 struct RequestReviewViewModifier: ViewModifier {
-    
+
+    enum Action {
+        case requestAfterDetailSettingsReturn
+    }
+
     // MARK: - Properties
-    
+
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "Unknown Bundle",
         category: "RequestReviewViewModifier"
     )
-    
+
     @Environment(\.requestReview) private var requestReview
-    
+
+    let action: Action
+    let isEnabled: Bool
+
     @AppStorage(AppUserDefaultsKeys.reviewCounter, store: AppUserDefaultsManager.shared.storage)
-    var reviewCounter = AppDefaultValues.reviewCounter
-    
+    private var reviewCounter = AppDefaultValues.reviewCounter
+
     @AppStorage(AppUserDefaultsKeys.lastBuildPromptedForReview, store: AppUserDefaultsManager.shared.storage)
-    var lastBuildPromptedForReview = AppDefaultValues.lastBuildPromptedForReview
-    
+    private var lastBuildPromptedForReview = AppDefaultValues.lastBuildPromptedForReview
+
     // MARK: - Content
-    
+
+    init(action: Action,
+         isEnabled: Bool) {
+        self.action = action
+        self.isEnabled = isEnabled
+    }
+
     func body(content: Content) -> some View {
         content
-            .onAppear {
-                reviewCounter += 1
-                Self.logger.debug("reviewCounter = \(reviewCounter)")
-            }
             .onDisappear {
-                guard let currentAppBuild = Bundle.appBuild else { return }
-                if reviewCounter >= 50, currentAppBuild != lastBuildPromptedForReview {
-                    reviewCounter = 0
-                    presentReview()
-                    lastBuildPromptedForReview = currentAppBuild
-                }
+                requestReviewAfterDetailSettingsReturnIfNeeded()
             }
     }
 }
@@ -48,6 +52,25 @@ struct RequestReviewViewModifier: ViewModifier {
 // MARK: - Private Methods
 
 private extension RequestReviewViewModifier {
+    func requestReviewAfterDetailSettingsReturnIfNeeded() {
+        guard action == .requestAfterDetailSettingsReturn else { return }
+
+        let result = RequestReviewPolicy.recordDetailSettingsReturnAndEvaluate(
+            reviewCounter: reviewCounter,
+            currentAppBuild: Bundle.appBuild,
+            lastBuildPromptedForReview: lastBuildPromptedForReview,
+            isEligible: isEnabled
+        )
+
+        reviewCounter = result.reviewCounter
+        lastBuildPromptedForReview = result.lastBuildPromptedForReview
+        Self.logger.debug("reviewCounter = \(reviewCounter)")
+
+        if result.shouldRequestReview {
+            presentReview()
+        }
+    }
+
     func presentReview() {
         Task {
             try? await Task.sleep(for: .seconds(1))

--- a/SYKeyboard/Presentation/Content/BannerAd/BannerAdLayoutPolicy.swift
+++ b/SYKeyboard/Presentation/Content/BannerAd/BannerAdLayoutPolicy.swift
@@ -1,0 +1,17 @@
+//
+//  BannerAdLayoutPolicy.swift
+//  SYKeyboard
+//
+//  Created by Codex on 6/19/26.
+//
+
+import Foundation
+
+enum BannerAdLayoutPolicy {
+    
+    // MARK: - Internal Methods
+    
+    static func containerHeight(adHeight: CGFloat, isAdReceived: Bool) -> CGFloat {
+        isAdReceived ? adHeight : 0
+    }
+}

--- a/SYKeyboard/Presentation/Content/BannerAd/BannerAdView.swift
+++ b/SYKeyboard/Presentation/Content/BannerAd/BannerAdView.swift
@@ -11,31 +11,37 @@ import OSLog
 import GoogleMobileAds
 
 struct BannerAdView: UIViewRepresentable {
-    
+
     // MARK: - Properties
-    
+
     let adSize: AdSize
     @Binding var isAdReceived: Bool
-    
+
     // MARK: - Internal Methods
-    
+
     func makeUIView(context: Context) -> UIView {
         let banner = BannerView(adSize: adSize)
         banner.adUnitID = Configuration.admobID
         banner.load(Request())
         banner.delegate = context.coordinator
-        
+
         let coordinator = context.coordinator
         banner.paidEventHandler = { [weak coordinator, weak banner] value in
             guard let banner else { return }
             coordinator?.handlePaidEvent(value: value, banner: banner)
         }
-        
+
         return banner
     }
-    
-    func updateUIView(_ uiView: UIView, context: Context) {}
-    
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        guard let banner = uiView as? BannerView,
+              banner.adSize.size != adSize.size else { return }
+
+        banner.adSize = adSize
+        banner.load(Request())
+    }
+
     func makeCoordinator() -> BannerAdCoordinator {
         return BannerAdCoordinator(parent: self)
     }
@@ -47,12 +53,12 @@ private extension BannerAdView {
     enum Configuration: String  {
         case debug
         case release
-        
+
         static var current: Configuration? {
             guard let buildConfigString = Bundle.main.infoDictionary?["Configuration"] as? String else { return nil }
             return Configuration(rawValue: buildConfigString.lowercased())
         }
-        
+
         static var admobID: String {
             switch current {
             case .release:

--- a/SYKeyboard/Presentation/Content/ContentView.swift
+++ b/SYKeyboard/Presentation/Content/ContentView.swift
@@ -6,43 +6,74 @@
 //
 
 import SwiftUI
+import OSLog
 
 import GoogleMobileAds
 
 struct ContentView: View {
-    
+
     // MARK: - Properties
-    
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "Unknown Bundle",
+        category: "ContentView"
+    )
+
+    @Environment(\.scenePhase) private var scenePhase
+
     @AppStorage(AppUserDefaultsKeys.isOnboarding, store: AppUserDefaultsManager.shared.storage)
     private var isOnboarding = AppDefaultValues.isOnboarding
-    
+
+    @AppStorage(AppUserDefaultsKeys.reviewCounter, store: AppUserDefaultsManager.shared.storage)
+    private var reviewCounter = AppDefaultValues.reviewCounter
+
+    @AppStorage(AppUserDefaultsKeys.lastBuildPromptedForReview, store: AppUserDefaultsManager.shared.storage)
+    private var lastBuildPromptedForReview = AppDefaultValues.lastBuildPromptedForReview
+
     @State private var isAdReceived: Bool = false
-    
+
+    @State private var hasRecordedReviewEligibleVisit: Bool = false
+
     // MARK: - Content
-    
+
     var body: some View {
         NavigationStack {
             GeometryReader { geometry in
                 let adSize = largeAnchoredAdaptiveBanner(width: geometry.size.width)
-                
+                let adHeight = BannerAdLayoutPolicy.containerHeight(
+                    adHeight: adSize.size.height,
+                    isAdReceived: isAdReceived
+                )
+
                 ZStack(alignment: .bottom) {
                     VStack {
                         KeyboardTestView()
-                        
+
                         KeyboardSettingsView()
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .safeAreaInset(edge: .bottom) {
                         BannerAdView(adSize: adSize, isAdReceived: $isAdReceived)
-                            .frame(maxWidth: .infinity, maxHeight: adSize.size.height)
+                            .frame(maxWidth: .infinity, maxHeight: adHeight)
                             .background(isAdReceived ? Color(.systemBackground) : .clear, ignoresSafeAreaEdges: .bottom)
                             .opacity(isAdReceived ? 1 : 0)
                             .allowsHitTesting(isAdReceived)
                             .animation(.easeInOut(duration: 1), value: isAdReceived)
                     }
                 }
+                .frame(width: geometry.size.width, height: geometry.size.height, alignment: .top)
             }
             .onAppear {
                 hideKeyboard()
+                recordReviewEligibleAppLaunchIfNeeded()
+            }
+            .onChange(of: scenePhase) { newPhase in
+                switch newPhase {
+                case .active, .inactive:
+                    recordReviewEligibleAppLaunchIfNeeded()
+                default:
+                    break
+                }
             }
             .navigationTitle(Bundle.displayName ?? "SY키보드")
             .navigationBarTitleDisplayMode(.inline)
@@ -52,6 +83,49 @@ struct ContentView: View {
                     .presentationDetents([.fraction(0.8)])
             }
         }
+    }
+}
+
+// MARK: - Private Methods
+
+private extension ContentView {
+    func recordReviewEligibleAppLaunchIfNeeded() {
+        guard !hasRecordedReviewEligibleVisit else { return }
+
+        let result = RequestReviewPolicy.recordEligibleInteraction(
+            reviewCounter: reviewCounter,
+            lastBuildPromptedForReview: lastBuildPromptedForReview,
+            isEligible: !isOnboarding && checkKeyboardExtensionEnabled()
+        )
+
+        guard result.reviewCounter != reviewCounter else { return }
+
+        hasRecordedReviewEligibleVisit = true
+        reviewCounter = result.reviewCounter
+        lastBuildPromptedForReview = result.lastBuildPromptedForReview
+        Self.logger.debug("reviewCounter = \(reviewCounter)")
+    }
+
+    /// 사용자의 "AppleKeyboards" 설정에 현재 앱의 키보드 확장이 포함되어 있는지 여부를 반환하는 메서드
+    func checkKeyboardExtensionEnabled() -> Bool {
+        // 사용자의 설정 데이터 가져옴
+        //   - "AppleKeyboards" 값은 사용자가 설정에서 활성화한 키보드 목록(예: "com.apple.keyboard.emoji", "com.thirdparty.customkeyboard")을 포함
+        guard let keyboards = UserDefaults.standard.dictionaryRepresentation()["AppleKeyboards"] as? [String] else {
+            return false
+        }
+
+        // 현재 앱의 Bundle ID에 "."을 붙여서 키보드 확장의 Bundle ID 패턴을 생성
+        //   - 메인 앱의 Bundle ID: "github.com-SNMac.SYKeyboard"
+        //     -> 키보드 Extension의 Bundle ID: "github.com-SNMac.SYKeyboard.keyboard"
+        let keyboardExtensionBundleIDPrefix = (Bundle.main.bundleIdentifier ?? "Unknown Bundle") + "."
+        for keyboard in keyboards {
+            // "AppleKeyboards" 목록을 순회하며 현재 앱의 키보드 확장이 포함되어 있는지 검사
+            if keyboard.hasPrefix(keyboardExtensionBundleIDPrefix) {
+                return true
+            }
+        }
+
+        return false
     }
 }
 

--- a/SYKeyboard/Presentation/Content/ContentView.swift
+++ b/SYKeyboard/Presentation/Content/ContentView.swift
@@ -95,7 +95,7 @@ private extension ContentView {
         let result = RequestReviewPolicy.recordEligibleInteraction(
             reviewCounter: reviewCounter,
             lastBuildPromptedForReview: lastBuildPromptedForReview,
-            isEligible: !isOnboarding && checkKeyboardExtensionEnabled()
+            isEligible: !isOnboarding && KeyboardExtensionAvailability.isEnabled()
         )
 
         guard result.reviewCounter != reviewCounter else { return }
@@ -104,28 +104,6 @@ private extension ContentView {
         reviewCounter = result.reviewCounter
         lastBuildPromptedForReview = result.lastBuildPromptedForReview
         Self.logger.debug("reviewCounter = \(reviewCounter)")
-    }
-
-    /// 사용자의 "AppleKeyboards" 설정에 현재 앱의 키보드 확장이 포함되어 있는지 여부를 반환하는 메서드
-    func checkKeyboardExtensionEnabled() -> Bool {
-        // 사용자의 설정 데이터 가져옴
-        //   - "AppleKeyboards" 값은 사용자가 설정에서 활성화한 키보드 목록(예: "com.apple.keyboard.emoji", "com.thirdparty.customkeyboard")을 포함
-        guard let keyboards = UserDefaults.standard.dictionaryRepresentation()["AppleKeyboards"] as? [String] else {
-            return false
-        }
-
-        // 현재 앱의 Bundle ID에 "."을 붙여서 키보드 확장의 Bundle ID 패턴을 생성
-        //   - 메인 앱의 Bundle ID: "github.com-SNMac.SYKeyboard"
-        //     -> 키보드 Extension의 Bundle ID: "github.com-SNMac.SYKeyboard.keyboard"
-        let keyboardExtensionBundleIDPrefix = (Bundle.main.bundleIdentifier ?? "Unknown Bundle") + "."
-        for keyboard in keyboards {
-            // "AppleKeyboards" 목록을 순회하며 현재 앱의 키보드 확장이 포함되어 있는지 검사
-            if keyboard.hasPrefix(keyboardExtensionBundleIDPrefix) {
-                return true
-            }
-        }
-
-        return false
     }
 }
 

--- a/SYKeyboard/Presentation/Content/KeyboardSettingsView.swift
+++ b/SYKeyboard/Presentation/Content/KeyboardSettingsView.swift
@@ -77,42 +77,16 @@ struct KeyboardSettingsView: View {
         .ignoresSafeArea(.keyboard, edges: .all)
         .scrollDismissesKeyboard(.immediately)
         .onAppear {
-            isKeyboardExtensionEnabled = checkKeyboardExtensionEnabled()
+            isKeyboardExtensionEnabled = KeyboardExtensionAvailability.isEnabled()
         }
         .onChange(of: scenePhase) { newPhase in
             switch newPhase {
             case .active, .inactive:
-                isKeyboardExtensionEnabled = checkKeyboardExtensionEnabled()
+                isKeyboardExtensionEnabled = KeyboardExtensionAvailability.isEnabled()
             default:
                 break
             }
         }
-    }
-}
-
-// MARK: - Private Methods
-
-private extension KeyboardSettingsView {
-    /// 사용자의 "AppleKeyboards" 설정에 현재 앱의 키보드 확장이 포함되어 있는지 여부를 반환하는 메서드
-    func checkKeyboardExtensionEnabled() -> Bool {
-        // 사용자의 설정 데이터 가져옴
-        //   - "AppleKeyboards" 값은 사용자가 설정에서 활성화한 키보드 목록(예: "com.apple.keyboard.emoji", "com.thirdparty.customkeyboard")을 포함
-        guard let keyboards = UserDefaults.standard.dictionaryRepresentation()["AppleKeyboards"] as? [String] else {
-            return false
-        }
-
-        // 현재 앱의 Bundle ID에 "."을 붙여서 키보드 확장의 Bundle ID 패턴을 생성
-        //   - 메인 앱의 Bundle ID: "github.com-SNMac.SYKeyboard"
-        //     -> 키보드 Extension의 Bundle ID: "github.com-SNMac.SYKeyboard.keyboard"
-        let keyboardExtensionBundleIDPrefix = (Bundle.main.bundleIdentifier ?? "Unknown Bundle") + "."
-        for keyboard in keyboards {
-            // "AppleKeyboards" 목록을 순회하며 현재 앱의 키보드 확장이 포함되어 있는지 검사
-            if keyboard.hasPrefix(keyboardExtensionBundleIDPrefix) {
-                return true
-            }
-        }
-
-        return false
     }
 }
 

--- a/SYKeyboard/Presentation/Content/KeyboardSettingsView.swift
+++ b/SYKeyboard/Presentation/Content/KeyboardSettingsView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct KeyboardSettingsView: View {
-    
+
     // MARK: - Properties
-    
+
     @Environment(\.scenePhase) private var scenePhase
+
     @State private var isKeyboardExtensionEnabled: Bool = false
-    
+
     // MARK: - Content
-    
+
     var body: some View {
         List {
             Section {
@@ -29,28 +30,28 @@ struct KeyboardSettingsView: View {
             .alignmentGuide(.listRowSeparatorLeading) { dimensions in
                 dimensions[.leading]
             }
-            
+
             HangeulKeyboardSelectView()
-            
+
             if isKeyboardExtensionEnabled {
                 Section {
                     FeedbackSettingsView()
                 } header: {
                     Text("피드백 설정")
                 }
-                
+
                 Section {
                     PredictiveTextSettingsView()
                 } header: {
                     Text("자동완성 텍스트 설정")
                 }
-                
+
                 Section {
                     InputSettingsView()
                 } header: {
                     Text("입력 설정")
                 }
-                
+
                 Section {
                     AppearanceSettingsView()
                 } header: {
@@ -63,7 +64,7 @@ struct KeyboardSettingsView: View {
                     Text("SY키보드를 설정에서 추가하시면 세부 설정이 가능합니다.")
                 }
             }
-            
+
             Section {
                 InfoView()
             } header: {
@@ -99,7 +100,7 @@ private extension KeyboardSettingsView {
         guard let keyboards = UserDefaults.standard.dictionaryRepresentation()["AppleKeyboards"] as? [String] else {
             return false
         }
-        
+
         // 현재 앱의 Bundle ID에 "."을 붙여서 키보드 확장의 Bundle ID 패턴을 생성
         //   - 메인 앱의 Bundle ID: "github.com-SNMac.SYKeyboard"
         //     -> 키보드 Extension의 Bundle ID: "github.com-SNMac.SYKeyboard.keyboard"
@@ -110,7 +111,7 @@ private extension KeyboardSettingsView {
                 return true
             }
         }
-        
+
         return false
     }
 }

--- a/SYKeyboard/Presentation/KeyboardSettings/CursorMovementSettingsView.swift
+++ b/SYKeyboard/Presentation/KeyboardSettings/CursorMovementSettingsView.swift
@@ -42,7 +42,7 @@ struct CursorMovementSettingsView: View {
             }
             .navigationTitle("커서 이동")
             .navigationBarTitleDisplayMode(.inline)
-            .requestReviewViewModifier()
+            .requestReviewOnDetailSettingsReturn()
         }.onDisappear {
             Analytics.setUserProperty(String(format: "%.1f", cursorActiveDistance),
                                       forName: "pref_cursor_atv_distance")

--- a/SYKeyboard/Presentation/KeyboardSettings/KeyboardHeightSettingsView.swift
+++ b/SYKeyboard/Presentation/KeyboardSettings/KeyboardHeightSettingsView.swift
@@ -53,7 +53,7 @@ struct KeyboardHeightSettingsView: View {
             updatePreviewKeyboardHeight()
         }.onChange(of: tempKeyboardHeight) { _ in
             updatePreviewKeyboardHeight()
-        }.requestReviewViewModifier()
+        }.requestReviewOnDetailSettingsReturn()
     }
 }
 

--- a/SYKeyboard/Presentation/KeyboardSettings/LongPressSettingsView.swift
+++ b/SYKeyboard/Presentation/KeyboardSettings/LongPressSettingsView.swift
@@ -41,7 +41,7 @@ struct LongPressSettingsView: View {
             }
             .navigationTitle("길게 누르기 입력")
             .navigationBarTitleDisplayMode(.inline)
-            .requestReviewViewModifier()
+            .requestReviewOnDetailSettingsReturn()
         }.onDisappear {
             Analytics.setUserProperty(String(format: "%.2f", longPressDuration),
                                       forName: "pref_long_press_duration")

--- a/SYKeyboard/Presentation/KeyboardSettings/OneHandedKeyboardWidthSettingsView.swift
+++ b/SYKeyboard/Presentation/KeyboardSettings/OneHandedKeyboardWidthSettingsView.swift
@@ -52,7 +52,7 @@ struct OneHandedKeyboardWidthSettingsView: View {
             tempOneHandedKeyboardWidth = oneHandedKeyboardWidth
             updatePreviewKeyboardHeight()
             updatePreviewLanguageBasedOnSystem()
-        }.requestReviewViewModifier()
+        }.requestReviewOnDetailSettingsReturn()
     }
 }
 

--- a/SYKeyboard/Presentation/Utils/Extensions/View+Extension.swift
+++ b/SYKeyboard/Presentation/Utils/Extensions/View+Extension.swift
@@ -12,7 +12,8 @@ extension View {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
     
-    func requestReviewViewModifier() -> some View {
-        modifier(RequestReviewViewModifier())
+    func requestReviewOnDetailSettingsReturn(isEnabled: Bool = true) -> some View {
+        modifier(RequestReviewViewModifier(action: .requestAfterDetailSettingsReturn,
+                                           isEnabled: isEnabled))
     }
 }

--- a/SYKeyboard/Presentation/Utils/KeyboardExtensionAvailability.swift
+++ b/SYKeyboard/Presentation/Utils/KeyboardExtensionAvailability.swift
@@ -1,0 +1,28 @@
+//
+//  KeyboardExtensionAvailability.swift
+//  SYKeyboard
+//
+//  Created by Codex on 6/19/26.
+//
+
+import Foundation
+
+enum KeyboardExtensionAvailability {
+
+    // MARK: - Properties
+
+    private static let appleKeyboardsKey = "AppleKeyboards"
+
+    // MARK: - Internal Methods
+
+    /// 사용자의 "AppleKeyboards" 설정에 현재 앱의 키보드 확장이 포함되어 있는지 여부를 반환하는 메서드
+    static func isEnabled(userDefaults: UserDefaults = .standard,
+                          bundleIdentifier: String? = Bundle.main.bundleIdentifier) -> Bool {
+        guard let keyboards = userDefaults.array(forKey: appleKeyboardsKey) as? [String] else {
+            return false
+        }
+
+        let keyboardExtensionBundleIDPrefix = (bundleIdentifier ?? "Unknown Bundle") + "."
+        return keyboards.contains { $0.hasPrefix(keyboardExtensionBundleIDPrefix) }
+    }
+}

--- a/SYKeyboardTests/Presentation/AppTrackingAuthorizationPolicyTests.swift
+++ b/SYKeyboardTests/Presentation/AppTrackingAuthorizationPolicyTests.swift
@@ -1,0 +1,70 @@
+//
+//  AppTrackingAuthorizationPolicyTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/19/26.
+//
+
+import Testing
+
+@testable import SYKeyboard
+
+@Suite("ATT 요청 정책 검증")
+struct AppTrackingAuthorizationPolicyTests {
+
+    @Test("온보딩 중에는 ATT 요청하지 않음")
+    func testDoesNotRequestDuringOnboarding() {
+        let result = AppTrackingAuthorizationPolicy.evaluateDidBecomeActive(
+            isTrackingAuthorizationNotDetermined: true,
+            isOnboarding: true,
+            isHandlingSettingsRedirect: false
+        )
+
+        #expect(result.shouldRequestAuthorization == false)
+        #expect(result.shouldClearSettingsRedirect == false)
+    }
+
+    @Test("설정 redirect 처리 중에는 ATT 요청하지 않고 redirect 상태를 해제")
+    func testDoesNotRequestDuringSettingsRedirectAndClearsRedirectState() {
+        let result = AppTrackingAuthorizationPolicy.evaluateDidBecomeActive(
+            isTrackingAuthorizationNotDetermined: true,
+            isOnboarding: false,
+            isHandlingSettingsRedirect: true
+        )
+
+        #expect(result.shouldRequestAuthorization == false)
+        #expect(result.shouldClearSettingsRedirect == true)
+    }
+
+    @Test("온보딩이 끝났고 redirect 중이 아니며 ATT 상태가 미결정이면 요청")
+    func testRequestsAfterOnboardingWhenStatusNotDetermined() {
+        let result = AppTrackingAuthorizationPolicy.evaluateDidBecomeActive(
+            isTrackingAuthorizationNotDetermined: true,
+            isOnboarding: false,
+            isHandlingSettingsRedirect: false
+        )
+
+        #expect(result.shouldRequestAuthorization == true)
+        #expect(result.shouldClearSettingsRedirect == false)
+    }
+    
+    @Test("온보딩이 닫히면 설정 redirect 중이 아닐 때 ATT 요청")
+    func testRequestsAfterOnboardingDismissed() {
+        let result = AppTrackingAuthorizationPolicy.evaluateOnboardingDismissed(
+            isTrackingAuthorizationNotDetermined: true,
+            isHandlingSettingsRedirect: false
+        )
+        
+        #expect(result.shouldRequestAuthorization == true)
+    }
+    
+    @Test("설정 redirect 중에는 온보딩이 닫혀도 ATT 요청하지 않음")
+    func testDoesNotRequestAfterOnboardingDismissedDuringSettingsRedirect() {
+        let result = AppTrackingAuthorizationPolicy.evaluateOnboardingDismissed(
+            isTrackingAuthorizationNotDetermined: true,
+            isHandlingSettingsRedirect: true
+        )
+        
+        #expect(result.shouldRequestAuthorization == false)
+    }
+}

--- a/SYKeyboardTests/Presentation/BannerAdLayoutPolicyTests.swift
+++ b/SYKeyboardTests/Presentation/BannerAdLayoutPolicyTests.swift
@@ -1,0 +1,25 @@
+//
+//  BannerAdLayoutPolicyTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/19/26.
+//
+
+import Foundation
+import Testing
+
+@testable import SYKeyboard
+
+@Suite("배너 광고 레이아웃 정책 검증")
+struct BannerAdLayoutPolicyTests {
+
+    @Test("광고를 받기 전에는 하단 safe area 높이를 확보하지 않음")
+    func testCollapsedHeightBeforeAdReceived() {
+        #expect(BannerAdLayoutPolicy.containerHeight(adHeight: 50, isAdReceived: false) == 0)
+    }
+
+    @Test("광고를 받은 뒤에만 광고 높이만큼 safe area를 확보")
+    func testUsesAdHeightAfterAdReceived() {
+        #expect(BannerAdLayoutPolicy.containerHeight(adHeight: 50, isAdReceived: true) == 50)
+    }
+}

--- a/SYKeyboardTests/Presentation/KeyboardExtensionAvailabilityTests.swift
+++ b/SYKeyboardTests/Presentation/KeyboardExtensionAvailabilityTests.swift
@@ -1,0 +1,77 @@
+//
+//  KeyboardExtensionAvailabilityTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/19/26.
+//
+
+import Foundation
+import Testing
+
+@testable import SYKeyboard
+
+@Suite("키보드 확장 활성화 확인 검증")
+struct KeyboardExtensionAvailabilityTests {
+
+    @Test("현재 앱의 키보드 확장이 AppleKeyboards에 있으면 활성화 상태")
+    func testEnabledWhenCurrentKeyboardExtensionExists() {
+        let (suiteName, userDefaults) = makeUserDefaults()
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(
+            [
+                "ko_KR@sw=Korean",
+                "com.example.SYKeyboard.keyboard",
+            ],
+            forKey: "AppleKeyboards"
+        )
+
+        let isEnabled = KeyboardExtensionAvailability.isEnabled(
+            userDefaults: userDefaults,
+            bundleIdentifier: "com.example.SYKeyboard"
+        )
+
+        #expect(isEnabled == true)
+    }
+
+    @Test("현재 앱의 키보드 확장이 AppleKeyboards에 없으면 비활성화 상태")
+    func testDisabledWhenCurrentKeyboardExtensionDoesNotExist() {
+        let (suiteName, userDefaults) = makeUserDefaults()
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(
+            [
+                "ko_KR@sw=Korean",
+                "com.example.OtherKeyboard.keyboard",
+            ],
+            forKey: "AppleKeyboards"
+        )
+
+        let isEnabled = KeyboardExtensionAvailability.isEnabled(
+            userDefaults: userDefaults,
+            bundleIdentifier: "com.example.SYKeyboard"
+        )
+
+        #expect(isEnabled == false)
+    }
+
+    @Test("AppleKeyboards 목록이 비어 있으면 비활성화 상태")
+    func testDisabledWhenAppleKeyboardsEmpty() {
+        let (suiteName, userDefaults) = makeUserDefaults()
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set([], forKey: "AppleKeyboards")
+
+        let isEnabled = KeyboardExtensionAvailability.isEnabled(
+            userDefaults: userDefaults,
+            bundleIdentifier: "com.example.SYKeyboard"
+        )
+
+        #expect(isEnabled == false)
+    }
+
+    private func makeUserDefaults() -> (suiteName: String, userDefaults: UserDefaults) {
+        let suiteName = "KeyboardExtensionAvailabilityTests.\(UUID().uuidString)"
+        return (suiteName, UserDefaults(suiteName: suiteName)!)
+    }
+}

--- a/SYKeyboardTests/Presentation/RequestReviewPolicyTests.swift
+++ b/SYKeyboardTests/Presentation/RequestReviewPolicyTests.swift
@@ -1,0 +1,75 @@
+//
+//  RequestReviewPolicyTests.swift
+//  SYKeyboardTests
+//
+//  Created by Codex on 6/19/26.
+//
+
+import Testing
+
+@testable import SYKeyboard
+
+@Suite("자동 리뷰 요청 정책 검증")
+struct RequestReviewPolicyTests {
+
+    @Test("앱 실행은 카운트만 증가시키고 즉시 요청하지 않음")
+    func testValidAppLaunchIncrementsCounterWithoutPrompting() {
+        let result = RequestReviewPolicy.recordEligibleInteraction(
+            reviewCounter: 29,
+            isEligible: true
+        )
+
+        #expect(result.reviewCounter == 30)
+        #expect(result.shouldRequestReview == false)
+    }
+
+    @Test("온보딩 또는 키보드 미추가 상태에서는 앱 실행을 카운트하지 않음")
+    func testInvalidAppLaunchDoesNotIncrementCounter() {
+        let result = RequestReviewPolicy.recordEligibleInteraction(
+            reviewCounter: 29,
+            isEligible: false
+        )
+
+        #expect(result.reviewCounter == 29)
+        #expect(result.shouldRequestReview == false)
+    }
+
+    @Test("상세 설정 복귀 시 1회 카운트한 뒤 기준 횟수와 빌드 조건을 만족하면 요청하고 카운터를 초기화")
+    func testDetailReturnRequestsReviewWhenThresholdReached() {
+        let result = RequestReviewPolicy.recordDetailSettingsReturnAndEvaluate(
+            reviewCounter: 29,
+            currentAppBuild: "100",
+            lastBuildPromptedForReview: "99",
+            isEligible: true
+        )
+
+        #expect(result.reviewCounter == 0)
+        #expect(result.lastBuildPromptedForReview == "100")
+        #expect(result.shouldRequestReview == true)
+    }
+
+    @Test("앱 실행은 기준 횟수를 채워도 즉시 요청하지 않음")
+    func testAppLaunchDoesNotPromptEvenWhenCounterReachesThreshold() {
+        let result = RequestReviewPolicy.recordEligibleInteraction(
+            reviewCounter: 29,
+            isEligible: true
+        )
+
+        #expect(result.reviewCounter == 30)
+        #expect(result.shouldRequestReview == false)
+    }
+
+    @Test("같은 빌드에서는 상세 설정 복귀 시에도 다시 요청하지 않음")
+    func testDetailReturnDoesNotRequestTwiceForSameBuild() {
+        let result = RequestReviewPolicy.recordDetailSettingsReturnAndEvaluate(
+            reviewCounter: 29,
+            currentAppBuild: "100",
+            lastBuildPromptedForReview: "100",
+            isEligible: true
+        )
+
+        #expect(result.reviewCounter == 30)
+        #expect(result.lastBuildPromptedForReview == "100")
+        #expect(result.shouldRequestReview == false)
+    }
+}

--- a/SYKeyboardTests/Presentation/RequestReviewPolicyTests.swift
+++ b/SYKeyboardTests/Presentation/RequestReviewPolicyTests.swift
@@ -12,6 +12,11 @@ import Testing
 @Suite("자동 리뷰 요청 정책 검증")
 struct RequestReviewPolicyTests {
 
+    @Test("리뷰 요청 기준 횟수는 30회")
+    func testThresholdIsThirtyInteractions() {
+        #expect(RequestReviewPolicy.threshold == 30)
+    }
+
     @Test("앱 실행은 카운트만 증가시키고 즉시 요청하지 않음")
     func testValidAppLaunchIncrementsCounterWithoutPrompting() {
         let result = RequestReviewPolicy.recordEligibleInteraction(

--- a/dev/active/code-review-scope/code-review-scope-context.md
+++ b/dev/active/code-review-scope/code-review-scope-context.md
@@ -89,7 +89,7 @@ Last Updated: 2026-06-14
 - `origin/develop..07a9ccfe`에는 리뷰 문서/운영 문서 변경만 있고 Track 7 메인 앱 runtime 코드는 `origin/develop`과 같다.
 - `sykeyboard://`는 현재 앱에 등록된 유일한 custom URL scheme이며 한글/영문 extension의 전체 접근 안내에서 시스템 설정 이동을 요청할 때 사용한다.
 - `SYKeyboardApp`은 custom URL 수신 시 시스템 설정을 열고, 같은 app lifecycle에서 ATT 상태가 `.notDetermined`이면 권한을 요청한다.
-- 독립 코드리뷰에서 iOS 26.5 시뮬레이터의 최초 권한 상태로 `sykeyboard://`를 열었을 때 Settings 위에 SYKeyboard ATT 팝업이 표시되는 것을 재현했다.
+- 기존 리뷰 당시에는 iOS 26.5 시뮬레이터의 최초 권한 상태로 `sykeyboard://`를 열었을 때 Settings 위에 SYKeyboard ATT 팝업이 표시되는 것을 재현했다. 현재 제품 동작에서는 iOS 26 이상 설정 이동 버튼을 숨기므로 남은 적용 범위는 iOS 26 미만의 설정 이동 버튼 경로다.
 - `ContentView`는 geometry 폭으로 adaptive banner 크기를 다시 계산하지만 `BannerAdView.updateUIView`는 비어 있다.
 - 광고 미수신 상태의 `.opacity(0)`와 `.allowsHitTesting(false)`는 `safeAreaInset` 내부 banner의 레이아웃 높이를 제거하지 않는다.
 - `RequestReviewViewModifier`와 `requestReviewViewModifier()` helper는 존재하지만 현재 앱 화면에는 적용되지 않는다.
@@ -207,7 +207,7 @@ Last Updated: 2026-06-14
 - 7번 리뷰에서 `requesting-code-review` 지침에 따라 독립 코드리뷰 서브에이전트를 실행하고 Track 7 findings를 로컬 코드 경로와 교차검증했다.
 - 7번 리뷰의 일반 샌드박스 `SYKeyboard` 빌드는 CoreSimulator/SwiftPM cache 권한 오류로 실패했다.
 - 같은 빌드를 권한 있는 환경에서 재실행했고 `iPhone 13 mini / iOS 16.0`에서 `BUILD SUCCEEDED`를 확인했다.
-- Track 7의 ATT/설정 이동 충돌은 독립 리뷰어가 iOS 26.5 시뮬레이터에서 재현했다. banner 레이아웃과 자동 리뷰 요청 findings는 코드 경로로 확인했으며 실제 UI 수동 검증이 남아 있다.
+- Track 7의 ATT/설정 이동 충돌은 기존 리뷰 당시 iOS 26.5 시뮬레이터에서 재현했으나, 현재 제품 동작에서는 iOS 26 이상 설정 이동 버튼을 숨긴다. 남은 적용 범위는 iOS 26 미만의 설정 이동 버튼 경로다. banner 레이아웃과 자동 리뷰 요청 findings는 코드 경로로 확인했으며 실제 UI 수동 검증이 남아 있다.
 - Track 7의 한국어 온보딩 문구 P3는 실제 안내, SwiftUI preview, String Catalog를 함께 수정하고 `Resolved` 처리했다.
 - 8번 리뷰에서 `requesting-code-review` 지침에 따라 독립 코드리뷰 서브에이전트를 실행하고 Track 8 findings를 로컬 project/package/산출물 경로와 교차검증했다.
 - 8번 리뷰의 일반 샌드박스 `xcodebuild -list -project SYKeyboard.xcodeproj`와 `swift package --package-path SYKeyboardAssets dump-package`는 CoreSimulator/SwiftPM cache 권한 오류로 실패했다.

--- a/dev/active/code-review-scope/code-review-scope-findings.md
+++ b/dev/active/code-review-scope/code-review-scope-findings.md
@@ -266,37 +266,37 @@ Last Updated: 2026-06-19
 
 ### Track 7. Main App Shell, Onboarding, Ads, And Resources
 
-#### [P2][Open] 설정 이동 deep link가 최초 ATT 권한 요청과 충돌함
+#### [P2][Resolved] 설정 이동 deep link가 최초 ATT 권한 요청과 충돌함
 
 - 위치: `SYKeyboard/App/SYKeyboardApp.swift:121`, `SYKeyboard/App/SYKeyboardApp.swift:126`
 - 영향: 전체 접근 안내에서 `sykeyboard://`로 앱을 열어 시스템 설정으로 이동하려는 최초 사용자가, 설정 앱 위에서 SYKeyboard의 추적 권한 팝업을 보게 되어 설정 흐름이 중단되고 권한 요청 맥락도 불명확해진다.
-- 근거: `.onOpenURL`은 즉시 시스템 설정을 열고, 인접한 `didBecomeActive` 구독은 ATT 상태가 `.notDetermined`이면 독립적으로 권한을 요청한다. 독립 코드리뷰에서 iOS 26.5 시뮬레이터의 최초 권한 상태로 `sykeyboard://`를 열었을 때 Settings가 foreground인 상태에서 SYKeyboard ATT 팝업이 표시되는 것을 재현했다.
-- 제안: ATT 요청을 온보딩 이후의 명시적인 앱 내부 시점으로 이동하거나, 설정 redirect를 처리하는 동안에는 ATT 요청을 보류한다.
-- 검증: ATT 권한을 초기화한 뒤 `sykeyboard://` 진입 시 Settings가 팝업 없이 열리는지 확인하고, 일반 앱 실행에서는 정한 앱 내부 시점에 ATT 요청이 표시되는지 확인한다.
+- 근거: `.onOpenURL`은 즉시 시스템 설정을 열고, 인접한 `didBecomeActive` 구독은 ATT 상태가 `.notDetermined`이면 독립적으로 권한을 요청한다. 기존 리뷰 당시에는 iOS 26.5 시뮬레이터에서 해당 충돌을 재현했으나, 현재 제품 동작에서는 iOS 26 이상 설정 이동 버튼을 숨긴다. 남은 적용 범위는 iOS 26 미만의 설정 이동 버튼 경로다.
+- 처리: `AppTrackingAuthorizationPolicy`를 추가해 온보딩 중이거나 설정 redirect 처리 중이면 ATT 요청을 보류하도록 했다. `sykeyboard://` 처리 시 `isHandlingSettingsRedirect`를 세우고, 다음 active notification에서 요청 없이 redirect 상태만 해제한다. 온보딩 모달을 닫아 `isOnboarding == false`가 되는 시점에는 설정 redirect 중이 아닐 때만 ATT 요청을 수행한다.
+- 검증: `AppTrackingAuthorizationPolicyTests`로 온보딩 중 요청 금지, 설정 redirect 중 요청 금지와 상태 해제, 온보딩 이후 일반 active 상태 요청 조건, 온보딩 모달 dismissal 직후 요청 조건을 확인했다. `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` 통과.
 
-#### [P2][Open] 화면 폭 변경 후 adaptive banner가 최초 크기를 유지함
+#### [P2][Resolved] 화면 폭 변경 후 adaptive banner가 최초 크기를 유지함
 
 - 위치: `SYKeyboard/Presentation/Content/ContentView.swift:28`, `SYKeyboard/Presentation/Content/BannerAd/BannerAdView.swift:37`
-- 영향: 회전 또는 iPad 창 크기 변경 후 SwiftUI가 확보한 광고 영역과 실제 로드된 banner 크기가 달라져 광고가 잘리거나 빈 공간이 생길 수 있다.
+- 영향: iPhone 세로 전용 앱에서도 초기 레이아웃 또는 safe-area 폭 재계산 시점에 SwiftUI가 확보한 광고 영역과 실제 로드된 banner 크기가 달라져 광고가 잘리거나 빈 공간이 생길 수 있다.
 - 근거: `ContentView`는 현재 `geometry.size.width`로 `adSize`를 다시 계산하지만, `BannerAdView.updateUIView(_:,context:)`가 비어 있어 이미 생성된 `BannerView`의 `adSize`와 광고 요청은 갱신되지 않는다.
-- 제안: `updateUIView`에서 새 크기와 현재 banner 크기를 비교해 `adSize`를 갱신하고 필요한 경우 광고를 다시 요청한다.
-- 검증: 광고 로드 후 기기 회전과 iPad 창 크기 변경을 수행해 `BannerView.adSize`, 실제 frame, SwiftUI 광고 영역이 일치하는지 확인한다.
+- 처리: `BannerAdView.updateUIView(_:context:)`에서 현재 `BannerView.adSize.size`와 새 `adSize.size`를 비교하고, 크기가 달라진 경우 `adSize`를 갱신한 뒤 광고를 다시 요청하도록 했다.
+- 검증: `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` 통과. iPhone 세로 환경에서 광고 성공/실패 상태 수동 검증은 남아 있다.
 
-#### [P2][Open] 광고를 받지 못해도 빈 하단 safe area가 유지됨
+#### [P2][Resolved] 광고를 받지 못해도 빈 하단 safe area가 유지됨
 
 - 위치: `SYKeyboard/Presentation/Content/ContentView.swift:36`
 - 영향: 네트워크 오류, 광고 재고 부족, 초기 로딩 중에도 설정 목록 아래에 광고 높이만큼 빈 공간이 남아 사용 가능한 화면 영역이 줄어든다.
 - 근거: `safeAreaInset` 내부의 `BannerAdView`는 항상 `adSize.size.height`까지 레이아웃에 참여한다. `isAdReceived == false`일 때 적용하는 `.opacity(0)`와 `.allowsHitTesting(false)`는 표시와 입력만 바꾸며 레이아웃 공간은 제거하지 않는다.
-- 제안: 광고 수신 성공 시에만 safe-area 높이를 확보하거나, 수신 상태에 따라 광고 container 높이를 0과 실제 높이 사이에서 전환한다.
-- 검증: 광고 요청을 실패시키거나 오프라인으로 실행해 하단 빈 공간이 없는지 확인하고, 광고 수신 후에만 설정 목록이 광고 높이만큼 안전하게 올라가는지 확인한다.
+- 처리: `BannerAdLayoutPolicy`를 추가해 광고 미수신 상태에서는 container 높이를 0으로 계산하고, 광고 수신 후에만 실제 광고 높이를 확보하도록 했다.
+- 검증: `BannerAdLayoutPolicyTests`로 광고 미수신/수신 상태의 container 높이를 확인했다. `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` 통과. 오프라인/광고 실패 수동 검증은 남아 있다.
 
-#### [P2][Open] 자동 인앱 리뷰 요청 modifier가 어떤 화면에도 연결되지 않음
+#### [P2][Resolved] 자동 인앱 리뷰 요청 기준이 상세 설정 화면에만 묶여 있음
 
 - 위치: `SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewViewModifier.swift:14`, `SYKeyboard/Presentation/Utils/Extensions/View+Extension.swift:15`
-- 영향: 사용자가 앱 화면을 반복 방문해도 `reviewCounter`가 증가하지 않고 자동 인앱 리뷰 요청이 절대 표시되지 않는다. 수동 App Store 리뷰 버튼만 동작한다.
-- 근거: `requestReviewViewModifier()` helper와 modifier 구현은 남아 있지만, 현재 Swift 파일에서 이를 적용하는 호출이 없다. Git 이력상 과거 설정 화면들에는 modifier가 적용되어 있었으므로 기능 연결이 제거된 상태다.
-- 제안: 자동 리뷰 요청을 유지할 계획이면 반복 방문을 의미하는 안정적인 화면에 modifier를 적용하고, 유지하지 않을 계획이면 modifier와 관련 저장 키를 제거해 의도를 명확히 한다.
-- 검증: 자동 요청을 유지할 경우 threshold 직전 counter로 대상 화면을 열고 닫아 counter 증가, build당 1회 제한, 요청 호출을 확인한다.
+- 영향: 기존 finding의 “어떤 화면에도 연결되지 않음” 전제는 현재 코드 기준 부정확했다. 다만 카운트 기준이 4개 상세 설정 화면 방문에만 묶여 있어 반복 사용 신호가 좁고, threshold 50회도 실제 요청까지 지나치게 보수적이었다.
+- 근거: 확인 시점에 `requestReviewViewModifier()`는 `LongPressSettingsView`, `KeyboardHeightSettingsView`, `CursorMovementSettingsView`, `OneHandedKeyboardWidthSettingsView`에 적용되어 있었다.
+- 처리: 리뷰 로직을 `RequestReviewPolicy`로 분리하고, 앱 실행과 상세 설정 복귀를 카운트 기준으로 삼도록 변경했다. 앱 실행은 카운트만 증가시키고, 실제 `requestReview()` 판단은 상세 설정 화면에서 메인 설정으로 돌아오는 시점에만 수행해 앱 시작 직후 팝업을 피한다. threshold는 30회로 낮췄고, build당 1회 제한은 유지했다.
+- 검증: `RequestReviewPolicyTests`로 앱 실행은 즉시 요청하지 않고, 상세 설정 복귀 시 카운트/threshold/build 조건을 만족할 때만 요청되는지 확인했다. `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` 통과.
 
 #### [P3][Resolved] 한 손 키보드 안내의 한국어 문구에 영문 `or`가 노출됨
 
@@ -373,8 +373,9 @@ Last Updated: 2026-06-19
 - Track 6의 EnglishKeyboard Debug/Release에 `APPLICATION_EXTENSION_API_ONLY = YES`를 적용하기로 결정했다. Track 8의 build/packaging 리뷰에서도 target별 설정 parity와 적용 후 빌드 결과를 다시 확인한다.
 - Track 6의 설정 이동 실패는 비핵심 best-effort 기능으로 유지한다. 사용자 실패 UI 대신 개발자 진단 로그만 후속 개선 대상으로 둔다.
 - Track 7 확인 결과 `sykeyboard://`는 현재 등록된 유일한 custom scheme이며 extension의 설정 이동 전용으로 사용되므로, URL 종류를 구분하지 않고 시스템 설정을 여는 현재 동작 자체는 finding으로 보지 않는다. 향후 다른 deep link를 추가할 때는 명시적인 URL routing을 먼저 정의한다.
-- Track 7의 ATT/설정 이동 충돌은 extension overlay에서 시작되는 사용자 흐름이지만 수정 책임은 메인 앱 lifecycle에 둔다.
-- Track 7의 banner 두 finding은 함께 수정하고, 광고 성공/실패 및 기기 회전/iPad resize 흐름을 수동 검증하는 편이 적절하다.
+- Track 7의 ATT/설정 이동 충돌은 extension overlay에서 시작되는 사용자 흐름이지만 수정 책임은 메인 앱 lifecycle에 둔다. `AppTrackingAuthorizationPolicy`로 온보딩/설정 redirect 중 요청을 보류하도록 처리했다.
+- Track 7의 banner 두 finding은 함께 수정했다. 앱은 iPhone 세로 전용이므로 회전/iPad resize 검증은 범위에서 제외하고, 광고 성공/실패 흐름은 수동 검증이 필요하다.
+- Track 7의 자동 인앱 리뷰 요청은 기존 finding의 미연결 전제가 현재 코드와 맞지 않아 범위를 재정의했다. 앱 실행은 카운트만 증가시키고, 상세 설정 복귀는 카운트 증가 후 요청 UI 표시 여부를 판단한다.
 - Track 7에서 `SYKeyboard/Resources/Info.plist` source에 `DeveloperEmail` key가 두 번 선언된 것을 확인했다. 빌드 결과에는 하나의 값만 남지만 source hygiene와 Firebase/config packaging 전반은 Track 8로 넘긴다.
 - Track 8에서 전체 review execution checklist가 완료됐다. 다음 단계는 Open findings의 수정 우선순위와 묶음을 결정하는 것이다.
 - fresh clone bootstrap 문서화 finding은 Xcode Cloud의 secret 생성 흐름이 저장소의 clean-environment 빌드 계약이고 CI/CD가 정상 수행된다는 사용자 확인에 따라 `Invalid` 처리했다.

--- a/dev/active/code-review-scope/code-review-scope-tasks.md
+++ b/dev/active/code-review-scope/code-review-scope-tasks.md
@@ -62,7 +62,7 @@ Last Updated: 2026-06-14
 - 7번 리뷰는 `requesting-code-review` 지침에 따라 독립 코드리뷰 서브에이전트 결과와 로컬 코드/리소스 경로 검토를 교차검증했다.
 - 7번 리뷰의 일반 샌드박스 `SYKeyboard` 빌드는 CoreSimulator/SwiftPM cache 권한 오류로 실패했고, 권한 있는 `iPhone 13 mini / iOS 16.0` 실행은 `BUILD SUCCEEDED`로 통과했다.
 - Track 7의 `sykeyboard://`는 현재 extension의 설정 이동 전용 URL이므로 URL 종류를 구분하지 않는 동작 자체는 finding으로 보지 않았다. 향후 다른 deep link를 추가할 때 명시적인 routing을 정의한다.
-- Track 7의 ATT 충돌은 iOS 26.5 시뮬레이터에서 재현됐고, banner 성공/실패 및 회전/resize와 자동 리뷰 요청 흐름은 실제 UI 수동 검증이 남아 있다.
+- Track 7의 ATT 충돌은 현재 제품 동작 기준으로 iOS 26 미만 설정 이동 버튼 경로에 적용된다. banner 성공/실패와 자동 리뷰 요청 흐름은 실제 UI 수동 검증이 남아 있다.
 - Track 7의 한국어 온보딩 문구 P3는 `or`를 `드래그하거나` 표현으로 수정하고 실제 안내, preview, String Catalog 반영을 확인해 `Resolved` 처리했다.
 - 8번 Build, Packaging, And Repository Hygiene 리뷰에서 fresh clone 빌드 준비 절차 부재 P2, Xcode 16+ 문서와 `swift-tools-version: 6.2` 계약 불일치 P2, 앱 번들에 저장소 문서/CI 스크립트 포함 P3, Meta mediation의 mutable `main` 의존 P3, 메인 앱 Info.plist 중복 key P3, generated SwiftPM workspace metadata 추적 P3를 발견해 `code-review-scope-findings.md`에 누적했다.
 - 8번 리뷰는 `requesting-code-review` 지침에 따라 독립 코드리뷰 서브에이전트 결과와 로컬 project/package/산출물 검토를 교차검증했다.

--- a/dev/active/issue-70-track-7-review/issue-70-track-7-review-context.md
+++ b/dev/active/issue-70-track-7-review/issue-70-track-7-review-context.md
@@ -1,0 +1,80 @@
+# Issue 70 Track 7 Review Context
+
+Last Updated: 2026-06-19
+
+## Relevant Files
+
+- `SYKeyboard/App/SYKeyboardApp.swift`: 앱 lifecycle, custom URL 처리, ATT 권한 요청이 있다.
+- `SYKeyboard/App/AppTrackingAuthorizationPolicy.swift`: 온보딩/설정 redirect 상태에 따른 ATT 요청 정책을 제공한다.
+- `SYKeyboard/Presentation/KeyboardSettings/InitialSettingsView.swift`: 메인 앱 내부의 시스템 설정 이동 버튼이다.
+- `Keyboards/HangeulKeyboard/Presentation/ViewController/HangeulKeyboardViewController.swift`: 키보드 extension에서 `sykeyboard://`를 여는 경로가 있다.
+- `Keyboards/EnglishKeyboard/Presentation/ViewController/EnglishKeyboardViewController.swift`: 키보드 extension에서 `sykeyboard://`를 여는 경로가 있다.
+- `SYKeyboard/Presentation/Content/ContentView.swift`: 광고 safe area와 onboarding sheet를 구성한다.
+- `SYKeyboard/Presentation/Content/BannerAd/BannerAdView.swift`: AdMob `BannerView`를 SwiftUI에 연결한다.
+- `SYKeyboard/Presentation/Content/BannerAd/BannerAdLayoutPolicy.swift`: 광고 수신 상태에 따른 safe-area container 높이를 계산한다.
+- `SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewViewModifier.swift`: 자동 리뷰 요청 counter와 build gate를 관리한다.
+- `SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewPolicy.swift`: 자동 리뷰 카운트와 요청 판단 정책을 순수 함수로 제공한다.
+- `SYKeyboard/Presentation/Utils/Extensions/View+Extension.swift`: 자동 리뷰 카운트/상세 복귀 요청 helper를 제공한다.
+- `SYKeyboard/Presentation/KeyboardSettings/LongPressSettingsView.swift`: 리뷰 modifier가 적용된 상세 설정 화면이다.
+- `SYKeyboard/Presentation/KeyboardSettings/KeyboardHeightSettingsView.swift`: 리뷰 modifier가 적용된 상세 설정 화면이다.
+- `SYKeyboard/Presentation/KeyboardSettings/CursorMovementSettingsView.swift`: 리뷰 modifier가 적용된 상세 설정 화면이다.
+- `SYKeyboard/Presentation/KeyboardSettings/OneHandedKeyboardWidthSettingsView.swift`: 리뷰 modifier가 적용된 상세 설정 화면이다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`: Issue #70의 원본 findings 상태를 관리한다.
+
+## Facts Checked
+
+- `gh api repos/SNMac/SYKeyboard/issues/70`로 이슈 본문을 확인했다.
+- 이슈 #70에는 댓글이 없고, 본문에 Track 7의 4개 P2 항목과 체크리스트가 있다.
+- `SYKeyboard/App/SYKeyboardApp.swift`는 `.onOpenURL`에서 `UIApplication.openSettingsURLString`을 열고, `didBecomeActive`에서 ATT `.notDetermined`이면 권한 요청을 시작한다.
+- `rg` 확인 결과 `ATTrackingManager.requestTrackingAuthorization()` 호출은 `SYKeyboard/App/SYKeyboardApp.swift` 한 곳뿐이다.
+- `ContentView`는 광고 수신 여부와 무관하게 `safeAreaInset` 내부에 `BannerAdView`를 배치하고 `adSize.size.height`를 frame 높이로 사용한다.
+- `BannerAdView.updateUIView(_:context:)`는 비어 있다.
+- `BannerAdCoordinator`는 광고 수신 성공 시 `isAdReceived = true`, 실패 시 `isAdReceived = false`로 상태를 전파한다.
+- `requestReviewViewModifier()` 호출은 4개 상세 설정 화면에 존재한다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`에는 Track 7의 4개 항목이 `[Open]`으로 남아 있다.
+- 자동 리뷰 요청 기준 보정 후 앱 실행은 카운트만 증가시키고, 상세 설정 화면 복귀는 카운트 증가 후 요청 여부를 판단한다.
+- 자동 리뷰 요청 threshold는 30회다.
+- `AppTrackingAuthorizationPolicy`는 온보딩 중이거나 설정 redirect 처리 중이면 ATT 요청을 하지 않는다. 설정 redirect 상태는 다음 active notification에서 해제한다.
+- 온보딩 모달을 닫아 `isOnboarding == false`가 되는 시점에는 설정 redirect 중이 아닐 때만 ATT 요청을 수행한다.
+- `BannerAdView.updateUIView(_:context:)`는 `BannerView.adSize.size`가 새 `adSize.size`와 다를 때 `adSize`를 갱신하고 광고를 다시 요청한다.
+- `BannerAdLayoutPolicy`는 광고 미수신 상태의 container 높이를 0으로 계산한다.
+
+## Decisions
+
+- ATT/deep link 항목은 수정 대상으로 본다.
+- adaptive banner 크기 갱신 항목은 수정 대상으로 본다.
+- 광고 실패 시 빈 하단 safe area 항목은 수정 대상으로 본다.
+- 자동 리뷰 요청 modifier 항목은 현재 코드 기준으로 “미연결” finding이 성립하지 않는다. 범위를 “상세 설정 화면에만 묶인 카운트 기준 보정”으로 재정의하고, 앱 실행도 카운트에 포함하도록 수정했다.
+- ATT/deep link 항목은 온보딩/설정 redirect guard 정책으로 수정했다. 최초 온보딩 사용자는 모달을 닫은 직후 ATT를 보고, `sykeyboard://` 설정 이동 중에는 ATT를 보지 않는다.
+- adaptive banner 크기 갱신 항목은 `updateUIView`에서 size 변경을 비교해 다시 load하는 방식으로 수정했다.
+- 광고 실패 시 빈 하단 safe area 항목은 광고 수신 상태에 따라 container 높이를 0/실제 광고 높이로 전환하는 방식으로 수정했다.
+
+## Open Questions
+
+- 자동 리뷰 요청은 앱 실행과 상세 설정 복귀를 카운트 기준으로 삼고, 요청 판단은 상세 설정 복귀 시점에만 수행한다.
+
+## Verification Notes
+
+- 실행한 명령:
+
+```sh
+git status --short
+gh api repos/SNMac/SYKeyboard/issues/70
+sed -n '1,220p' SYKeyboard/App/SYKeyboardApp.swift
+sed -n '1,220p' SYKeyboard/Presentation/Content/ContentView.swift
+sed -n '1,220p' SYKeyboard/Presentation/Content/BannerAd/BannerAdView.swift
+sed -n '1,180p' SYKeyboard/Presentation/Content/BannerAd/BannerAdCoordinator.swift
+rg -n "requestReviewViewModifier|RequestReviewViewModifier|reviewCounter|requestReview|SKStoreReviewController|Review" SYKeyboard Modules Keyboards SYKeyboardTests
+rg -n "AppTrackingTransparency|ATTrackingManager|trackingAuthorizationStatus|requestTrackingAuthorization" SYKeyboard Keyboards Modules SYKeyboardTests
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- `gh issue view 70 --repo SNMac/SYKeyboard --comments`는 GitHub GraphQL의 classic Projects deprecation 오류로 실패했다.
+- 같은 이슈 본문은 `gh api repos/SNMac/SYKeyboard/issues/70`로 확인했다.
+- 자동 리뷰 요청 정책 테스트 추가 후 `xcodebuild test`가 통과했다.
+- 일반 샌드박스의 `xcodebuild build`는 `CoreSimulatorService connection became invalid`, SwiftPM/clang cache `Operation not permitted` 오류로 실패했다.
+- 같은 `xcodebuild build` 명령을 권한 있는 실행으로 재시도해 `BUILD SUCCEEDED`를 확인했다.
+- ATT/banner 정책 테스트 추가 후 `xcodebuild test`를 다시 실행했고 `TEST SUCCEEDED`를 확인했다.
+- ATT/banner 수정 후 일반 샌드박스의 `xcodebuild build`는 동일한 권한 오류로 실패했고, 권한 있는 실행으로 재시도해 `BUILD SUCCEEDED`를 확인했다.
+- 온보딩 dismissal ATT 정책 테스트 추가 후 `xcodebuild test`를 다시 실행했고 `TEST SUCCEEDED`를 확인했다.

--- a/dev/active/issue-70-track-7-review/issue-70-track-7-review-plan.md
+++ b/dev/active/issue-70-track-7-review/issue-70-track-7-review-plan.md
@@ -1,0 +1,123 @@
+# Issue 70 Track 7 Review Plan
+
+Last Updated: 2026-06-19
+
+## Goal
+
+- GitHub Issue #70의 Track 7 리뷰 항목을 현재 코드 기준으로 검증하고, 타당한 항목만 수정한다.
+
+## Current State
+
+- 관련 이슈: `https://github.com/SNMac/SYKeyboard/issues/70`
+- 관련 findings 문서: `dev/active/code-review-scope/code-review-scope-findings.md`
+- 관련 파일:
+  - `SYKeyboard/App/SYKeyboardApp.swift`
+  - `SYKeyboard/Presentation/Content/ContentView.swift`
+  - `SYKeyboard/Presentation/Content/BannerAd/BannerAdView.swift`
+  - `SYKeyboard/Presentation/KeyboardSettings/InitialSettingsView.swift`
+  - `SYKeyboard/Presentation/Components/ViewModifiers/RequestReviewViewModifier.swift`
+  - `SYKeyboard/Presentation/Utils/Extensions/View+Extension.swift`
+  - `SYKeyboard/Presentation/KeyboardSettings/LongPressSettingsView.swift`
+  - `SYKeyboard/Presentation/KeyboardSettings/KeyboardHeightSettingsView.swift`
+  - `SYKeyboard/Presentation/KeyboardSettings/CursorMovementSettingsView.swift`
+  - `SYKeyboard/Presentation/KeyboardSettings/OneHandedKeyboardWidthSettingsView.swift`
+
+## Review Item Evaluation
+
+### 1. [P2] 설정 이동 deep link가 최초 ATT 권한 요청과 충돌함
+
+- 판단: 타당함.
+- 확인한 사실:
+  - `SYKeyboard/App/SYKeyboardApp.swift`의 `.onOpenURL`은 URL 종류와 무관하게 `UIApplication.openSettingsURLString`을 연다.
+  - 같은 view chain의 `UIApplication.didBecomeActiveNotification` 구독은 ATT 상태가 `.notDetermined`이면 즉시 `ATTrackingManager.requestTrackingAuthorization()`을 호출한다.
+  - `sykeyboard://`는 키보드 extension의 전체 접근 안내에서 사용된다.
+- 수정 방향:
+  - 설정 redirect 중에는 ATT 요청을 보류한다.
+  - 가능하면 ATT 요청 시점을 온보딩 sheet가 내려간 뒤의 메인 앱 내부 상태로 제한한다.
+  - `didBecomeActive`에서 무조건 요청하는 구조는 제거하거나 guard를 둔다.
+
+### 2. [P2] 화면 폭 변경 후 adaptive banner가 최초 크기를 유지함
+
+- 판단: 타당함.
+- 확인한 사실:
+  - `ContentView`는 `GeometryReader`의 `geometry.size.width`로 매 렌더링마다 `largeAnchoredAdaptiveBanner(width:)`를 계산한다.
+  - `BannerAdView.updateUIView(_:context:)`가 비어 있어 생성된 `BannerView`의 `adSize`와 광고 요청이 갱신되지 않는다.
+- 수정 방향:
+  - `updateUIView`에서 `uiView`를 `BannerView`로 캐스팅하고 현재 `adSize`와 새 `adSize`를 비교한다.
+  - 크기가 달라졌을 때 `banner.adSize`를 갱신하고 광고를 다시 요청한다.
+  - 같은 크기에서는 중복 load를 피한다.
+
+### 3. [P2] 광고를 받지 못해도 빈 하단 safe area가 유지됨
+
+- 판단: 타당함.
+- 확인한 사실:
+  - `safeAreaInset(edge: .bottom)` 내부의 `BannerAdView`가 항상 `adSize.size.height`만큼 frame에 참여한다.
+  - `opacity(0)`와 `allowsHitTesting(false)`는 레이아웃 높이를 제거하지 않는다.
+- 수정 방향:
+  - 광고 수신 전 또는 실패 상태에서는 container 높이를 0으로 둔다.
+  - 광고 수신 후에만 `adSize.size.height`만큼 safe-area 공간을 확보한다.
+  - `BannerAdCoordinator`는 광고 실패 시 이미 `isAdReceived = false`로 복구하므로 `ContentView`의 높이 전환에 집중한다.
+
+### 4. [P2] 자동 인앱 리뷰 요청 modifier가 어떤 화면에도 연결되지 않음
+
+- 판단: 현재 코드 기준으로는 미연결 finding이 비타당함. 다만 카운트 기준과 threshold 보정은 필요함.
+- 확인한 사실:
+  - `requestReviewViewModifier()` 호출은 다음 4개 화면에 존재한다.
+    - `SYKeyboard/Presentation/KeyboardSettings/LongPressSettingsView.swift`
+    - `SYKeyboard/Presentation/KeyboardSettings/KeyboardHeightSettingsView.swift`
+    - `SYKeyboard/Presentation/KeyboardSettings/CursorMovementSettingsView.swift`
+    - `SYKeyboard/Presentation/KeyboardSettings/OneHandedKeyboardWidthSettingsView.swift`
+  - 따라서 “어떤 화면에도 연결되지 않음”이라는 finding은 현재 코드와 맞지 않는다.
+- 처리:
+  - 기능 제거는 하지 않는다.
+  - 앱 실행을 카운트 기준에 추가한다.
+  - 앱 시작 직후 요청 UI가 뜨지 않도록 앱 실행은 카운트만 증가시킨다.
+  - 실제 요청 판단은 상세 설정 화면에서 메인 설정으로 돌아오는 시점에 유지한다.
+  - threshold는 30회로 낮춘다.
+
+## Approach
+
+1. ATT 요청과 설정 redirect 충돌을 먼저 수정한다.
+2. 광고 banner 크기 갱신과 빈 safe area 문제는 같은 변경 묶음으로 수정한다.
+3. 리뷰 modifier 항목은 미연결 전제를 정정하고, 앱 실행 카운트 + 상세 복귀 카운트/요청 판단으로 보정한다.
+4. 수정 후 `dev/active/code-review-scope/code-review-scope-findings.md`와 이 작업 문서의 상태를 갱신한다.
+
+## Risks
+
+- ATT 팝업은 iOS 정책과 시스템 상태에 의존하므로 자동 테스트만으로는 충분히 검증하기 어렵다.
+- 광고 로딩은 네트워크, AdMob SDK, 테스트 광고 응답에 의존하므로 수동 확인 또는 로그 확인이 필요하다.
+- safe area 높이를 0으로 전환할 때 광고 수신 직후 목록 하단이 급격히 움직일 수 있다. 기존 animation 의도를 유지할지 확인해야 한다.
+- 자동 리뷰 요청은 시스템이 실제 팝업 표시를 보장하지 않으므로 counter와 build gate 중심으로 검증해야 한다.
+
+## Verification
+
+- 실행할 기본 빌드:
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- 필요 시 전체 테스트:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- 수동 확인:
+  - ATT 권한 상태를 초기화한 뒤 키보드 extension의 전체 접근 안내에서 `sykeyboard://` 흐름으로 진입해 Settings가 팝업 없이 열리는지 확인한다.
+  - 일반 앱 실행에서는 온보딩 이후 정한 앱 내부 시점에 ATT 요청이 표시되는지 확인한다.
+  - iPhone 세로 환경에서 광고 로드 후 `BannerView.adSize`, frame, SwiftUI 하단 영역이 일치하는지 확인한다.
+  - 광고 실패 또는 오프라인 상태에서 하단 빈 공간이 남지 않는지 확인한다.
+
+## Done Criteria
+
+- 타당한 3개 항목이 코드로 수정된다.
+- 리뷰 modifier 항목은 현재 코드 기준으로 범위 재정의 상태가 문서에 반영된다.
+- `SYKeyboard` scheme 빌드가 통과하거나, 실행하지 못한 이유와 환경 오류가 기록된다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`의 Track 7 상태가 갱신된다.

--- a/dev/active/issue-70-track-7-review/issue-70-track-7-review-tasks.md
+++ b/dev/active/issue-70-track-7-review/issue-70-track-7-review-tasks.md
@@ -1,0 +1,19 @@
+# Issue 70 Track 7 Review Tasks
+
+Last Updated: 2026-06-19
+
+## Checklist
+
+- [x] Issue #70 본문을 확인한다.
+- [x] `dev/README.md`, `dev/templates/`, `dev/codex-skill-playbook.md`를 확인한다.
+- [x] Track 7 관련 파일을 읽고 리뷰 항목의 전제를 검증한다.
+- [x] 각 리뷰 항목을 타당/비타당으로 분류한다.
+- [x] dev active 작업 문서를 만든다.
+- [x] `BannerAdCoordinator`를 읽고 광고 성공/실패 상태 전파를 확인한다.
+- [x] ATT 요청 시점과 설정 redirect guard를 구현한다.
+- [x] adaptive banner 크기 변경 시 `BannerView`를 갱신하도록 구현한다.
+- [x] 광고 미수신 상태에서 하단 safe area 높이가 0이 되도록 구현한다.
+- [x] 리뷰 modifier finding을 현재 코드 기준으로 findings 문서에 정정한다.
+- [x] 변경 범위에 맞는 `SYKeyboard` scheme 빌드 또는 테스트를 실행한다.
+- [x] `git status --short`로 의도하지 않은 변경이 없는지 확인한다.
+- [x] 완료 내용과 검증 결과를 최종 응답에 요약한다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #70

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 설정 이동 deep link 처리 중에는 ATT 요청을 보류하고, 온보딩 종료 시점에만 ATT 요청을 판단하도록 정책을 분리했습니다.
- 자동 인앱 리뷰 요청 기준을 앱 실행과 상세 설정 복귀 카운트 기반으로 조정하고, 요청 UI는 상세 설정 복귀 시점에만 판단하도록 정리했습니다.
- 광고 미수신 상태의 하단 safe area를 접고, banner 크기 변경 시 `BannerView`를 갱신하도록 보정했습니다.
- Track 7 리뷰 문서와 정책 테스트를 추가/갱신했습니다.

<br>

## ✅ 검증
<!-- 실행한 빌드/테스트 명령과 결과를 작성해주세요. 실행하지 못했다면 이유를 적어주세요. -->
- `rg -n "threshold는 10|10회|메인 설정 유효 방문|KeyboardSettingsView.*유효 방문|recordMainSettingsVisit|recordAppLaunch" SYKeyboard SYKeyboardTests dev/active/code-review-scope dev/active/issue-70-track-7-review`
  - 결과 없음
- `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - `TEST SUCCEEDED`
- `xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - 일반 샌드박스 실행은 CoreSimulatorService 및 SwiftPM/clang cache 권한 오류로 실패
  - 권한 있는 실행으로 재시도해 `BUILD SUCCEEDED`

<!-- Codex 샌드박스 오류로 재실행한 경우 일반 실행 실패와 권한 있는 실행 결과를 구분해서 적어주세요. -->

<br>
