### PR TITLE
Docs#71 Track 8 빌드 패키징 findings 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ xcuserdata
 ### SwiftPM ###
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+**/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 
 ### Xcode ###

--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,6 @@ xcuserdata
 
 ### SwiftPM ###
 .swiftpm/configuration/registries.json
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 **/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
 
 ## 코드 스타일
 
-- Swift 5 프로젝트이며 Xcode 16 이상을 기준으로 한다. `SYKeyboardAssets` 패키지는 `swift-tools-version: 6.2`를 사용한다.
+- Swift 5 프로젝트이며 Xcode 16 이상을 기준으로 한다. `SYKeyboardAssets` 패키지는 `swift-tools-version: 6.0`을 사용한다.
 - 자세한 코딩 컨벤션은 `dev/coding-conventions.md`를 따른다. 새 Swift 코드를 작성하기 전 관련 섹션을 먼저 확인한다.
 - 기존 스타일처럼 `// MARK: -` 섹션, 명확한 접근 제어, 짧은 한국어 주석을 유지한다.
 - Swift, Foundation, UIKit, SwiftUI가 제공하는 표준 API를 우선 사용한다. 예를 들어 UIKit gesture의 위치/속도처럼 프레임워크가 직접 제공하는 값이 있으면 별도 프레임워크 import나 직접 계산보다 이를 먼저 검토한다.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@
 
 ## 🔨 개발 환경
 ![Static Badge|67](https://img.shields.io/badge/Swift%205-%23F05138?logo=swift&logoColor=white)
-![Static Badge](https://img.shields.io/badge/Xcode%2016%20~-%23147EFB?logo=xcode&logoColor=white)
 ![Static Badge|55](https://img.shields.io/badge/16%20~%20-%23000000?logo=ios&logoColor=white)
+
+로컬 SPM 패키지는 `swift-tools-version: 6.0` manifest를 기준으로 한다.
 
 <br><br>
 
@@ -752,4 +753,3 @@ direction LR
 | <img width="300" alt="메인 앱 3" src="https://github.com/user-attachments/assets/c9ce4a05-0061-45ea-b5ae-46072c5ac976" width="300"> | <img width="300" alt="메인 앱 3 - 영어" src="https://github.com/user-attachments/assets/968b4cc3-562f-47d5-b097-bc055e932531" width="300"> |
 
 <br><br>
-

--- a/SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/SYKeyboardAssets/Package.swift
+++ b/SYKeyboardAssets/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/dev/active/code-review-scope/code-review-scope-findings.md
+++ b/dev/active/code-review-scope/code-review-scope-findings.md
@@ -313,13 +313,17 @@ Last Updated: 2026-06-19
 - 위치: `.gitignore:154`, `ci_scripts/ci_post_clone.sh:12`, `SYKeyboard.xcodeproj/project.pbxproj:949`, `AGENTS.md:79`
 - 판단: 저장소의 clean-environment 빌드 계약은 Xcode Cloud의 `ci_post_clone.sh`가 환경변수를 검증하고 `Secrets.xcconfig`와 Firebase plist를 생성하는 흐름이다. 사용자가 이 흐름에서 CI/CD 빌드와 테스트가 정상 수행됨을 확인했으며, 로컬 fresh clone bootstrap은 지원 요구사항이 아니므로 finding에서 제외한다.
 
-#### [P2][Open] 문서의 Xcode 16+ 지원 기준과 로컬 package 최소 tools version이 일치하지 않음
+#### [P2][Resolved] 문서의 Xcode 16+ 지원 기준과 로컬 package 최소 tools version이 일치하지 않음
 
 - 위치: `README.md:50`, `AGENTS.md:52`, `SYKeyboardAssets/Package.swift:1`
 - 영향: Xcode 16 이상이면 개발 가능한 것으로 안내되지만, `SYKeyboardAssets` manifest는 Swift tools 6.2 이상을 요구해 낮은 버전 Xcode에서 package graph 해석 전에 막힐 수 있다.
-- 근거: README와 AGENTS는 Xcode 16+를 기준으로 선언하고, package manifest는 최소 tools version을 `6.2`로 선언한다. 현재 검증 환경은 Xcode 26.5 / Swift 6.3.2뿐이다.
-- 제안: 실제 최소 지원 Xcode를 문서에 명시하거나, package가 Swift tools 6.2 기능을 사용하지 않는다면 지원하려는 Xcode에 맞춰 tools version을 낮추고 검증한다.
-- 검증: 문서에 선언할 최소 Xcode에서 `xcodebuild -list`와 `SYKeyboard` 빌드를 실행한다.
+- 근거: 최초 리뷰 시점에는 README와 AGENTS가 Xcode 16+를 기준으로 선언하고, package manifest는 최소 tools version을 `6.2`로 선언했다. 현재 검증 환경은 Xcode 26.5 / Swift 6.3.2다.
+- 처리: `SYKeyboardAssets/Package.swift`의 tools version을 `6.0`으로 낮췄다. README에서는 Xcode 버전 badge를 제거하고 local package tools version만 명시했으며, AGENTS의 package tools version 설명도 `swift-tools-version: 6.0` 기준으로 맞췄다.
+- 검증:
+  - 일반 샌드박스의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 Xcode/SwiftPM 캐시와 CoreSimulator 권한 오류로 실패했다.
+  - 권한 있는 환경의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 package graph를 정상 해석하고 project/scheme 목록을 출력했다.
+  - 권한 있는 환경의 `xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`는 `BUILD SUCCEEDED`를 확인했다.
+  - README에서 Xcode 버전 기준을 제거했으므로 별도 Xcode 16.0 실환경 검증은 필수 조건으로 두지 않는다.
 
 #### [P3][Resolved] 저장소 문서와 CI 스크립트가 메인 앱 번들에 포함됨
 
@@ -345,13 +349,15 @@ Last Updated: 2026-06-19
 - 처리: 중복 선언 하나를 제거했다.
 - 검증: source plist의 `DeveloperEmail` key가 하나인 것과 `plutil -lint` 통과, 새 app bundle의 processed plist에 key가 하나인 것을 확인했다.
 
-#### [P3][Open] generated SwiftPM workspace metadata가 git에 추적됨
+#### [P3][Resolved] generated SwiftPM workspace metadata가 git에 추적됨
 
 - 위치: `SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata:1`, `.gitignore:128`
 - 영향: 생성 가능한 workspace metadata가 불필요한 리뷰 변경을 만들고 저장소의 ignore 정책과 어긋난다.
 - 근거: 해당 파일과 정확히 일치하는 ignore 규칙이 있지만 파일은 이미 git에 추적되어 있다.
-- 제안: 파일을 git 추적에서 제거하고 현재 ignore 규칙을 유지한다.
-- 검증: package를 Xcode에서 다시 연 뒤 `git status --short`가 깨끗한지 확인한다.
+- 처리: `SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`를 git index에서 제거했다. 기존 root `.swiftpm/...` ignore 규칙만으로는 `SYKeyboardAssets/.swiftpm/...`가 ignore되지 않는 것을 확인해 `**/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 규칙을 추가했다.
+- 검증:
+  - `git ls-files SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 출력이 비어 있음을 확인했다.
+  - `git check-ignore -v SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`가 `.gitignore`의 nested SwiftPM workspace ignore 규칙을 출력하는 것을 확인했다.
 
 ## Handoff
 
@@ -383,3 +389,4 @@ Last Updated: 2026-06-19
 - Meta mediation package는 전이 의존성이 아니라 프로젝트에 직접 추가된 의존성이다. release version 기반 requirement로 다시 추가하고 빌드를 검증해 mutable `main` branch finding을 `Resolved` 처리했다.
 - `SYKeyboardAssets` resource bundle에는 ignored `.DS_Store`가 포함되지 않아 추가 finding으로 보지 않는다.
 - Track 6의 EnglishKeyboard `APPLICATION_EXTENSION_API_ONLY` parity finding은 `Resolved` 처리했고, Track 8에서 중복 finding을 추가하지 않았다.
+- Issue #71의 남은 Track 8 open findings 두 개는 처리와 권한 있는 빌드 검증을 마쳤다. README에서 Xcode 버전 기준을 제거했으므로 검증 기준은 현재 실사용 환경인 Xcode 26.5로 기록한다.

--- a/dev/active/issue-71-track-8-hygiene/issue-71-track-8-hygiene-context.md
+++ b/dev/active/issue-71-track-8-hygiene/issue-71-track-8-hygiene-context.md
@@ -1,0 +1,91 @@
+# Issue 71 Track 8 Hygiene Context
+
+Last Updated: 2026-06-20
+
+## Relevant Files
+
+- `README.md`: 개발 환경 섹션에서 Swift/iOS와 local package tools version을 안내한다.
+- `AGENTS.md`: 프로젝트 작업 기준으로 Xcode 16 이상과 `SYKeyboardAssets` tools version을 설명한다.
+- `SYKeyboardAssets/Package.swift`: 로컬 SPM package manifest이며 현재 `swift-tools-version: 6.2`를 선언한다.
+- `.gitignore`: SwiftPM/Xcode generated workspace metadata ignore 규칙을 포함한다.
+- `SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`: ignore 대상과 일치하지만 git에 추적 중인 generated metadata다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`: Track 8 findings의 원본 추적 문서다.
+
+## Facts Checked
+
+- GitHub Issue #71 REST API 확인 결과 이슈 제목은 `[Task] 코드리뷰 Track 8 - Build, Packaging, And Repository Hygiene findings 처리`다.
+- Issue #71 본문에는 open checklist 2개가 있다.
+  - `[P2] 문서의 Xcode 16+ 지원 기준과 로컬 package 최소 tools version이 일치하지 않음`
+  - `[P3] generated SwiftPM workspace metadata가 git에 추적됨`
+- Issue #71에는 추가 issue comment가 없다.
+- 최초 확인 시점의 `README.md`에는 `Xcode 16 ~` badge가 있었다.
+- `AGENTS.md`에는 `Swift 5 프로젝트이며 Xcode 16 이상을 기준으로 한다. SYKeyboardAssets 패키지는 swift-tools-version: 6.2를 사용한다.`는 설명이 있다.
+- `SYKeyboardAssets/Package.swift` 첫 줄은 `// swift-tools-version: 6.2`다.
+- `SYKeyboardAssets/Package.swift` 첫 줄을 `// swift-tools-version: 6.0`으로 변경했다.
+- `README.md` 개발 환경 섹션에 로컬 SPM package가 `swift-tools-version: 6.0` manifest 기준이라는 설명을 추가했다.
+- 사용자 변경으로 `README.md`의 Xcode 버전 badge가 제거됐다. README의 local package 설명도 Xcode 버전을 직접 언급하지 않도록 조정했다.
+- `AGENTS.md`의 `SYKeyboardAssets` tools version 설명을 `6.0`으로 변경했다.
+- 현재 로컬 도구 버전:
+  - `xcodebuild -version`: `Xcode 26.5`, `Build version 17F42`
+  - `xcrun swift --version`: `Apple Swift version 6.3.2`
+- `SYKeyboardAssets/Package.swift`는 Swift tools 6.2 전용으로 보이는 manifest 기능을 사용하지 않는다.
+- `.gitignore`에는 `.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 규칙이 있다.
+- `git ls-files SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`는 해당 파일이 추적 중임을 보여준다.
+- 해당 workspace metadata 파일 내용은 `self:` FileRef만 담은 생성 가능한 XML이다.
+- 추적 제거 후 기존 `.gitignore` 규칙만으로는 `SYKeyboardAssets/.swiftpm/...` 파일이 ignore되지 않아 `**/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 규칙을 추가했다.
+- `git ls-files SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 출력이 비어 있음을 확인했다.
+- `git check-ignore -v SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`가 `.gitignore:129` 규칙을 출력했다.
+- 일반 샌드박스의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 Xcode/SwiftPM 캐시와 CoreSimulator 권한 오류로 실패했다.
+- 권한 있는 환경의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 package graph 해석과 scheme 목록 출력을 완료했다.
+- 권한 있는 환경의 `xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`는 `BUILD SUCCEEDED`를 확인했다.
+- 작업 시작 시 `git status --short --branch`는 `task/#71-track-8...origin/task/#71-track-8`만 표시했고, tracked/untracked 변경은 없었다.
+
+## Decisions
+
+- 두 리뷰 항목은 모두 타당한 finding으로 보고 수정했다.
+- [P2]는 문서를 Xcode 26.x 기준으로 올리는 것보다 `SYKeyboardAssets` tools version을 낮추는 방향으로 처리했다.
+- [P2]의 최종 검증은 현재 실사용 환경인 Xcode 26.5 기준으로 기록한다. README에서 Xcode 버전 기준을 제거했으므로 Xcode 16 실환경 검증은 필수 조건으로 두지 않는다.
+- [P3]는 generated file을 git index에서 제거하고, nested package 경로까지 ignore되도록 `.gitignore`를 보강했다.
+
+## Open Questions
+
+- AGENTS의 내부 작업 기준인 Xcode 16 이상 설명도 README처럼 버전 없는 표현으로 바꿀지 여부는 별도 결정이 필요하다.
+
+## Verification Notes
+
+- 실행한 명령:
+
+```sh
+git status --short
+sed -n '1,240p' dev/README.md
+find dev/templates -maxdepth 1 -type f -print
+gh issue view 71 --repo SNMac/SYKeyboard --comments
+gh api repos/SNMac/SYKeyboard/issues/71
+gh api repos/SNMac/SYKeyboard/issues/71/comments --paginate
+sed -n '1,220p' dev/templates/task-plan-template.md
+sed -n '1,220p' dev/templates/task-context-template.md
+sed -n '1,220p' dev/templates/task-tasks-template.md
+sed -n '1,220p' dev/codex-skill-playbook.md
+sed -n '1,140p' README.md
+sed -n '1,140p' AGENTS.md
+sed -n '1,220p' SYKeyboardAssets/Package.swift
+sed -n '110,145p' .gitignore
+git ls-files SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+xcodebuild -version
+rg -n "Track 8|Xcode 16|generated SwiftPM|swift-tools-version|package.xcworkspace|DeveloperEmail|mutable" dev/active/code-review-scope/code-review-scope-findings.md README.md AGENTS.md SYKeyboardAssets/Package.swift .gitignore
+git ls-files -s SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+sed -n '1,80p' SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+xcrun swift --version
+sed -n '309,390p' dev/active/code-review-scope/code-review-scope-findings.md
+git status --short --branch
+git rm --cached SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+xcodebuild -list -project SYKeyboard.xcodeproj
+git check-ignore -v SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- `gh issue view`는 GitHub GraphQL의 classic Projects deprecation 오류로 실패했지만, REST API 조회는 성공했다.
+- 첫 `gh issue view` 일반 실행은 네트워크 제한으로 실패했고, 권한 있는 실행으로 REST API를 조회했다.
+- `git rm --cached` 일반 실행은 `.git/index.lock` 생성 권한 오류로 실패했고, 권한 있는 실행으로 재시도해 성공했다.
+- `xcodebuild -list` 일반 실행은 샌드박스 권한 오류로 실패했고, 권한 있는 실행에서 성공했다.
+- `xcodebuild build`는 권한 있는 환경에서 성공했다.

--- a/dev/active/issue-71-track-8-hygiene/issue-71-track-8-hygiene-plan.md
+++ b/dev/active/issue-71-track-8-hygiene/issue-71-track-8-hygiene-plan.md
@@ -1,0 +1,100 @@
+# Issue 71 Track 8 Hygiene Plan
+
+Last Updated: 2026-06-20
+
+## Goal
+
+- GitHub Issue #71의 Track 8 open findings를 코드베이스 현실과 대조해 타당성을 판단하고, 타당한 항목의 수정 계획과 검증 기준을 정한다.
+
+## Current State
+
+- GitHub Issue #71의 open finding 2개는 타당한 항목으로 판단했고, 수정까지 적용했다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`의 Track 8 해당 항목은 `Resolved`로 갱신했다.
+- 관련 파일:
+  - `README.md`
+  - `AGENTS.md`
+  - `SYKeyboardAssets/Package.swift`
+  - `.gitignore`
+  - `SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`
+  - `dev/active/code-review-scope/code-review-scope-findings.md`
+
+## Review Evaluation
+
+### [P2] Xcode 16+ 문서 기준과 Swift tools 6.2 불일치
+
+- 판단: 타당하다.
+- 확인한 사실:
+  - 최초 확인 시점의 `README.md`는 개발 환경 badge로 `Xcode 16 ~`를 표시했다.
+  - 사용자 변경으로 현재 `README.md`의 Xcode 버전 badge는 제거됐다.
+  - `AGENTS.md`는 Swift 5 프로젝트이며 Xcode 16 이상 기준이라고 설명한다.
+  - 최초 확인 시점의 `SYKeyboardAssets/Package.swift`는 `// swift-tools-version: 6.2`를 선언했다.
+  - 현재 `SYKeyboardAssets/Package.swift`는 `// swift-tools-version: 6.0`을 선언한다.
+  - 현재 로컬 검증 환경은 `Xcode 26.5`, `Apple Swift version 6.3.2`다.
+  - `SYKeyboardAssets/Package.swift`는 `.iOS(.v16)`, `.library`, `.target`, `.process("Resources")`만 사용한다.
+- 기술 판단:
+  - 문서가 말하는 최소 개발 환경과 package manifest가 요구하는 최소 Swift tools version이 서로 다른 것은 실제 bootstrap 실패로 이어질 수 있다.
+  - 현재 manifest 내용만 보면 Swift tools 6.2 전용 기능을 쓰는 근거는 확인되지 않았다.
+- 처리 방향:
+  - `SYKeyboardAssets/Package.swift`의 tools version을 `6.0`으로 낮췄다.
+  - README는 Xcode 버전 badge를 제거하고 local package의 tools version만 안내한다.
+  - 현재 실사용 환경인 Xcode 26.5에서 package graph 해석과 앱 빌드를 검증했다.
+
+### [P3] generated SwiftPM workspace metadata 추적
+
+- 판단: 타당하다.
+- 확인한 사실:
+  - `.gitignore`에 `.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` ignore 규칙이 있다.
+  - `git ls-files` 결과 `SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`가 이미 추적 중이다.
+  - 파일 내용은 Xcode/SwiftPM이 재생성 가능한 workspace metadata다.
+- 기술 판단:
+  - ignore 규칙과 실제 추적 상태가 충돌한다.
+  - 생성 파일이므로 소스 산출물로 유지할 이유가 확인되지 않았다.
+- 권장 수정 방향:
+  - `git rm --cached SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`로 index에서만 제거한다.
+  - 작업트리 파일은 삭제해도 Xcode가 재생성할 수 있으나, 이번 finding의 핵심은 추적 제거다.
+
+## Approach
+
+1. `SYKeyboardAssets/Package.swift`의 tools version을 `6.0`으로 낮췄다.
+2. README와 AGENTS의 개발 환경 설명을 `swift-tools-version: 6.0` 기준과 맞췄다.
+3. SwiftPM generated workspace metadata를 git 추적에서 제거했다.
+4. nested SwiftPM workspace metadata도 ignore되도록 `.gitignore` 규칙을 보강했다.
+5. `dev/active/code-review-scope/code-review-scope-findings.md`에서 두 finding의 상태와 처리/검증 결과를 갱신했다.
+
+## Risks
+
+- AGENTS에는 여전히 내부 작업 기준으로 Xcode 16 이상 표현이 남아 있다. README처럼 버전 없는 표현으로 바꿀지는 별도 결정이 필요하다.
+- generated workspace 파일 제거는 staged deletion으로 남는다. 최종 커밋 전 `git status --short`로 범위를 확인해야 한다.
+
+## Verification
+
+- 현재 환경에서 실행할 검증:
+
+```sh
+xcodebuild -list -project SYKeyboard.xcodeproj
+```
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+```sh
+git status --short
+```
+
+- 실행 결과:
+  - 일반 샌드박스의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 Xcode/SwiftPM 캐시와 CoreSimulator 권한 오류로 실패했다.
+  - 권한 있는 환경의 `xcodebuild -list -project SYKeyboard.xcodeproj`는 package graph 해석과 scheme 목록 출력을 완료했다.
+  - 권한 있는 환경의 `xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`는 `BUILD SUCCEEDED`를 확인했다.
+  - `git ls-files` 결과 generated workspace metadata는 더 이상 추적되지 않는다.
+  - `git check-ignore -v` 결과 nested SwiftPM workspace metadata가 `.gitignore` 규칙으로 ignore된다.
+
+## Done Criteria
+
+- `SYKeyboardAssets/Package.swift`와 문서의 최소 개발 환경 설명이 서로 충돌하지 않는다.
+- SwiftPM generated workspace metadata가 더 이상 git 추적 대상이 아니다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`의 Issue #71 관련 open finding 상태가 갱신된다.
+- 가능한 빌드 또는 package graph 검증 결과가 기록된다.

--- a/dev/active/issue-71-track-8-hygiene/issue-71-track-8-hygiene-tasks.md
+++ b/dev/active/issue-71-track-8-hygiene/issue-71-track-8-hygiene-tasks.md
@@ -1,0 +1,21 @@
+# Issue 71 Track 8 Hygiene Tasks
+
+Last Updated: 2026-06-20
+
+## Checklist
+
+- [x] `dev/README.md`와 `dev/templates/`를 확인한다.
+- [x] GitHub Issue #71 본문과 코멘트를 확인한다.
+- [x] `dev/active/code-review-scope/code-review-scope-findings.md`의 Track 8 open findings를 확인한다.
+- [x] [P2] Xcode/tools version finding의 관련 파일과 현재 도구 버전을 확인한다.
+- [x] [P3] SwiftPM generated workspace metadata finding의 ignore 규칙과 git 추적 상태를 확인한다.
+- [x] 각 리뷰 항목의 타당성을 판단한다.
+- [x] 타당한 항목의 수정 방향과 검증 기준을 문서화한다.
+- [x] `SYKeyboardAssets/Package.swift` tools version을 최소 지원 Xcode 정책에 맞게 조정한다.
+- [x] `README.md`/`AGENTS.md`의 개발 환경 설명을 실제 manifest와 맞춘다.
+- [x] `SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`를 git 추적에서 제거한다.
+- [x] nested SwiftPM workspace metadata가 ignore되도록 `.gitignore` 규칙을 보강한다.
+- [x] `dev/active/code-review-scope/code-review-scope-findings.md`에 처리 상태와 검증 결과를 반영한다.
+- [x] 변경 범위에 맞는 `xcodebuild -list` 또는 build 검증을 실행한다.
+- [x] `git status --short`로 의도하지 않은 변경이 없는지 확인한다.
+- [x] 완료 내용과 검증 결과를 최종 응답에 요약한다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #71
- #57

<br>

## 📝 작업 내용
- `SYKeyboardAssets` local package의 `swift-tools-version`을 `6.0`으로 낮춰 문서 기준과 manifest 요구 버전 불일치를 해소했습니다.
- README의 Xcode 버전 badge를 제거하고 local package tools version 안내만 남겼습니다.
- SwiftPM generated workspace metadata를 git 추적에서 제거하고 nested `.swiftpm` workspace metadata ignore 규칙을 추가했습니다.
- Track 8 findings 문서와 Issue #71 작업 문서에 처리 상태와 검증 결과를 반영했습니다.

<br>

## ✅ 검증
- 일반 샌드박스: `xcodebuild -list -project SYKeyboard.xcodeproj` 실행 시 Xcode/SwiftPM 캐시 및 CoreSimulator 권한 오류로 실패했습니다.
- 권한 있는 환경: `xcodebuild -list -project SYKeyboard.xcodeproj` 성공했습니다.
- 권한 있는 환경: `xcodebuild build -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` 성공했습니다.
- `git diff --check` 통과했습니다.
- `git ls-files SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 출력이 비어 있음을 확인했습니다.
- `git check-ignore -v SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`로 nested SwiftPM workspace metadata가 ignore됨을 확인했습니다.

<br>
