### PR TITLE
Fix/#85 선택 텍스트 문맥 기반 리턴 키 활성화

### DIFF
--- a/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift
@@ -17,10 +17,9 @@ enum KeyboardPresentationStatePolicy {
     ) -> Bool {
         guard enablesReturnKeyAutomatically else { return true }
 
-        let hasTextBeforeInput = documentContextBeforeInput?.isEmpty == false
-        let hasSelectedText = selectedText?.isEmpty == false
-        let hasTextAfterInput = documentContextAfterInput?.isEmpty == false
-        return hasTextBeforeInput || hasSelectedText || hasTextAfterInput
+        return documentContextBeforeInput?.isEmpty == false
+        || selectedText?.isEmpty == false
+        || documentContextAfterInput?.isEmpty == false
     }
 
     static func shouldHideSuggestionBar(

--- a/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift
@@ -12,13 +12,15 @@ enum KeyboardPresentationStatePolicy {
     static func isReturnButtonEnabled(
         enablesReturnKeyAutomatically: Bool,
         documentContextBeforeInput: String?,
+        selectedText: String?,
         documentContextAfterInput: String?
     ) -> Bool {
         guard enablesReturnKeyAutomatically else { return true }
 
         let hasTextBeforeInput = documentContextBeforeInput?.isEmpty == false
+        let hasSelectedText = selectedText?.isEmpty == false
         let hasTextAfterInput = documentContextAfterInput?.isEmpty == false
-        return hasTextBeforeInput || hasTextAfterInput
+        return hasTextBeforeInput || hasSelectedText || hasTextAfterInput
     }
 
     static func shouldHideSuggestionBar(

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -998,6 +998,7 @@ private extension BaseKeyboardViewController {
         let isEnabled = KeyboardPresentationStatePolicy.isReturnButtonEnabled(
             enablesReturnKeyAutomatically: textDocumentProxy.enablesReturnKeyAutomatically == true,
             documentContextBeforeInput: textDocumentProxy.documentContextBeforeInput,
+            selectedText: textDocumentProxy.selectedText,
             documentContextAfterInput: textDocumentProxy.documentContextAfterInput
         )
         returnButtonList.forEach { $0.updateEnabled(isEnabled) }

--- a/SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift
+++ b/SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift
@@ -18,6 +18,7 @@ struct KeyboardPresentationStatePolicyTests {
         let isEnabled = KeyboardPresentationStatePolicy.isReturnButtonEnabled(
             enablesReturnKeyAutomatically: false,
             documentContextBeforeInput: nil,
+            selectedText: nil,
             documentContextAfterInput: nil
         )
 
@@ -30,6 +31,7 @@ struct KeyboardPresentationStatePolicyTests {
             KeyboardPresentationStatePolicy.isReturnButtonEnabled(
                 enablesReturnKeyAutomatically: true,
                 documentContextBeforeInput: nil,
+                selectedText: nil,
                 documentContextAfterInput: nil
             ) == false
         )
@@ -37,6 +39,7 @@ struct KeyboardPresentationStatePolicyTests {
             KeyboardPresentationStatePolicy.isReturnButtonEnabled(
                 enablesReturnKeyAutomatically: true,
                 documentContextBeforeInput: "가",
+                selectedText: nil,
                 documentContextAfterInput: nil
             ) == true
         )
@@ -44,8 +47,37 @@ struct KeyboardPresentationStatePolicyTests {
             KeyboardPresentationStatePolicy.isReturnButtonEnabled(
                 enablesReturnKeyAutomatically: true,
                 documentContextBeforeInput: nil,
+                selectedText: nil,
                 documentContextAfterInput: "나"
             ) == true
+        )
+    }
+
+    @Test("return 자동 활성화가 켜져 있으면 선택된 텍스트만 있어도 활성화")
+    func testReturn자동활성화켜짐_선택텍스트존재시활성화() {
+        #expect(
+            KeyboardPresentationStatePolicy.isReturnButtonEnabled(
+                enablesReturnKeyAutomatically: true,
+                documentContextBeforeInput: nil,
+                selectedText: "전체 선택",
+                documentContextAfterInput: nil
+            ) == true
+        )
+        #expect(
+            KeyboardPresentationStatePolicy.isReturnButtonEnabled(
+                enablesReturnKeyAutomatically: true,
+                documentContextBeforeInput: "",
+                selectedText: " ",
+                documentContextAfterInput: ""
+            ) == true
+        )
+        #expect(
+            KeyboardPresentationStatePolicy.isReturnButtonEnabled(
+                enablesReturnKeyAutomatically: true,
+                documentContextBeforeInput: "",
+                selectedText: "",
+                documentContextAfterInput: ""
+            ) == false
         )
     }
 

--- a/dev/active/code-review-scope/code-review-scope-findings.md
+++ b/dev/active/code-review-scope/code-review-scope-findings.md
@@ -359,6 +359,20 @@ Last Updated: 2026-06-19
   - `git ls-files SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` 출력이 비어 있음을 확인했다.
   - `git check-ignore -v SYKeyboardAssets/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata`가 `.gitignore`의 nested SwiftPM workspace ignore 규칙을 출력하는 것을 확인했다.
 
+### Track 9. Selected Text Context Handling
+
+#### [P2][Resolved] return 자동 활성화 판단이 선택된 텍스트를 텍스트 존재 여부에 포함하지 않음
+
+- 위치: `Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift:12`, `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift:998`, `SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift:57`
+- 영향: `enablesReturnKeyAutomatically`가 켜진 텍스트 필드에서 전체 텍스트가 선택된 상태이면 `documentContextBeforeInput`과 `documentContextAfterInput`이 모두 비어 있을 수 있다. 이 경우 실제로 선택된 텍스트가 있는데도 return 버튼이 비활성화될 수 있다.
+- 근거: `UITextInputTraits.enablesReturnKeyAutomatically` SDK 헤더는 text widget contents의 zero-length/non-zero-length 상태에 따라 return key를 자동 비활성/활성화한다고 설명하고, `UITextDocumentProxy` SDK 헤더는 custom keyboard 문맥으로 `documentContextBeforeInput`, `documentContextAfterInput`, `selectedText`를 별도 제공한다. 기존 정책은 before/after만 확인했다.
+- 처리: `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)`에 `selectedText` 입력을 추가하고, before/selected/after 중 하나라도 비어 있지 않으면 return을 활성화하도록 변경했다. `BaseKeyboardViewController.updateReturnButtonEnabled()`는 `textDocumentProxy.selectedText`를 함께 전달한다.
+- 검증:
+  - 구현 전 `KeyboardPresentationStatePolicyTests`에 `selectedText` 파라미터와 selected text 전용 케이스를 먼저 추가했고, 기존 production API가 인자를 받지 못해 `extra argument 'selectedText' in call`로 실패하는 RED를 확인했다.
+  - 구현 후 `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/KeyboardPresentationStatePolicyTests`에서 `TEST SUCCEEDED`를 확인했다.
+  - 같은 destination의 전체 `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`도 `TEST SUCCEEDED`를 확인했다.
+  - 두 테스트 실행 모두 연결된 잠금 기기 관련 `DTDKRemoteDeviceConnection` 경고를 출력했지만, 시뮬레이터 테스트는 exit code 0으로 완료됐다.
+
 ## Handoff
 
 - Track 2부터 각 리뷰 채팅의 findings는 이 문서의 `## Findings` 아래에 트랙별 섹션으로 추가한다.

--- a/dev/active/selected-text-return-key/selected-text-return-key-context.md
+++ b/dev/active/selected-text-return-key/selected-text-return-key-context.md
@@ -1,0 +1,83 @@
+# Selected Text Return Key Context
+
+Last Updated: 2026-06-20
+
+## Relevant Files
+
+- `Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift`: return 버튼 활성화 정책이 before/after 문맥만 확인한다.
+- `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift`: `updateReturnButtonEnabled()`에서 정책에 `textDocumentProxy` 문맥을 전달한다.
+- `SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift`: return 자동 활성화 정책 테스트가 있다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`: 전체 코드리뷰 findings 추적 문서이며 처리 결과를 갱신해야 한다.
+
+## Facts Checked
+
+- GitHub Issue #85는 열린 bug 이슈이며 댓글은 없다.
+- 이슈 #85의 실제 open finding은 `[P2] return 자동 활성화 판단이 선택된 텍스트를 텍스트 존재 여부에 포함하지 않음` 하나다.
+- `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)` 현재 시그니처는 `enablesReturnKeyAutomatically`, `documentContextBeforeInput`, `documentContextAfterInput`만 받는다.
+- `BaseKeyboardViewController.updateReturnButtonEnabled()`는 현재 `textDocumentProxy.documentContextBeforeInput`과 `documentContextAfterInput`만 전달한다.
+- `SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift`는 before 또는 after에 텍스트가 있을 때 활성화되는 케이스를 검증하지만 `selectedText`만 있는 케이스는 없다.
+- SDK 헤더 `UIInputViewController.h`에서 `UITextDocumentProxy`는 `documentContextBeforeInput`, `documentContextAfterInput`, `selectedText`를 제공한다.
+- SDK 헤더 `UITextInputTraits.h`에서 `enablesReturnKeyAutomatically`는 text widget contents의 zero-length/non-zero-length 상태에 따라 return key를 자동 비활성/활성화한다고 설명한다.
+- `BaseKeyboardViewController`의 삭제, 반복 삭제, 자동완성 선택 경로는 이미 `textDocumentProxy.selectedText`를 별도로 전달한다.
+- `currentTextContextSnapshot()`은 before/after만 담고 undo/redo cursor anchor에 사용된다.
+- 구현 후 `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)`는 `selectedText`를 명시 입력으로 받는다.
+- 구현 후 `BaseKeyboardViewController.updateReturnButtonEnabled()`는 `textDocumentProxy.selectedText`를 전달한다.
+
+## Evaluation
+
+- 타당함: selected text가 존재하면 text widget contents는 비어 있지 않은 상태로 해석하는 것이 `enablesReturnKeyAutomatically` 계약과 맞다.
+- 타당함: custom keyboard에서 전체 선택 상태일 때 before/after 문맥이 비어 있을 수 있으므로, before/after만 보는 현재 정책은 false negative를 낼 수 있다.
+- 타당함: 수정 범위는 return 버튼 표시 정책과 해당 테스트로 한정할 수 있으며, 입력 조합/삭제/커서 이동 정책을 바꿀 필요는 없다.
+
+## Decisions
+
+- `selectedText`를 return 활성화 정책의 명시 입력으로 추가한다.
+- `selectedText`가 `nil`이거나 빈 문자열이면 기존 before/after 판단과 동일하게 동작하게 한다.
+- `selectedText`가 공백 문자열만 포함하더라도 비어 있지 않으면 text contents가 있는 것으로 보고 활성화한다. 기존 before/after도 `isEmpty == false`만 확인하므로 같은 기준을 따른다.
+- Track 9 handoff에서 제외한 snapshot, cursor drag, period shortcut, delete/repeat delete/suggestion selection 경로는 수정하지 않는다.
+
+## Open Questions
+
+- 실제 host 앱에서 전체 선택 상태일 때 before/after가 항상 빈 문자열 또는 nil로 노출되는지는 입력 필드 종류별로 다를 수 있다. 정책상 selected text를 포함하면 해당 차이에 더 안전하다.
+- 수동 확인용 host 화면이 별도로 준비되어 있는지는 아직 확인하지 않았다. 자동 테스트로 정책은 검증할 수 있다.
+
+## Verification Notes
+
+- 실행한 명령:
+
+```sh
+git status --short
+gh api repos/SNMac/SYKeyboard/issues/85
+gh api repos/SNMac/SYKeyboard/issues/85/comments
+sed -n '1,220p' Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift
+sed -n '940,1040p' Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+sed -n '1,220p' SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift
+rg -n "isReturnButtonEnabled|selectedText|updateReturnButtonEnabled|KeyboardTextContextSnapshot|currentTextContextSnapshot|CursorDragAccelerationPolicy|KeyboardPeriodShortcutPolicy|shouldRepeatDelete" Modules Keyboards SYKeyboard SYKeyboardTests
+sed -n '16,30p' /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIInputViewController.h
+sed -n '250,260p' /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks/UIKit.framework/Headers/UITextInputTraits.h
+```
+
+- `gh issue view 85 --repo SNMac/SYKeyboard --comments`는 GitHub classic Projects GraphQL 필드 오류로 실패했다. 이슈 본문과 댓글은 `gh api`로 확인했다.
+- TDD RED: `KeyboardPresentationStatePolicyTests`에 `selectedText` 파라미터와 selected text 전용 케이스를 먼저 추가한 뒤 focused 테스트를 실행했고, 기존 production API가 인자를 받지 못해 `extra argument 'selectedText' in call`로 실패했다.
+- 구현 후 focused 테스트:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/KeyboardPresentationStatePolicyTests
+```
+
+- 결과: `TEST SUCCEEDED`
+- 구현 후 전체 테스트:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- 결과: `TEST SUCCEEDED`
+- 두 테스트 실행 모두 연결된 잠금 기기 관련 `DTDKRemoteDeviceConnection` 경고를 출력했지만, 시뮬레이터 테스트는 exit code 0으로 완료됐다.

--- a/dev/active/selected-text-return-key/selected-text-return-key-plan.md
+++ b/dev/active/selected-text-return-key/selected-text-return-key-plan.md
@@ -1,0 +1,80 @@
+# Selected Text Return Key Plan
+
+Last Updated: 2026-06-20
+
+## Goal
+
+- GitHub Issue #85의 `[P2] return 자동 활성화 판단이 선택된 텍스트를 텍스트 존재 여부에 포함하지 않음` finding을 수정한다.
+
+## Current State
+
+- 판단: finding은 타당하며 수정 완료했다.
+- `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)`는 `documentContextBeforeInput`, `selectedText`, `documentContextAfterInput`을 확인한다.
+- `BaseKeyboardViewController.updateReturnButtonEnabled()`는 `textDocumentProxy.selectedText`를 함께 전달한다.
+- `UITextInputTraits.enablesReturnKeyAutomatically` SDK 헤더는 text widget contents가 zero-length이면 return key를 비활성화하고 non-zero-length이면 활성화한다고 설명한다.
+- `UITextDocumentProxy` SDK 헤더에는 custom keyboard가 접근할 수 있는 문맥으로 `documentContextBeforeInput`, `documentContextAfterInput`, `selectedText`가 별도 속성으로 존재한다.
+- 전체 텍스트가 선택되어 before/after가 비어 있고 `selectedText`만 있는 경우에도 return 자동 활성화 정책이 활성화된다.
+- 관련 파일:
+  - `Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardPresentationStatePolicy.swift`
+  - `Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift`
+  - `SYKeyboardTests/Utils/KeyboardPresentationStatePolicyTests.swift`
+  - `dev/active/code-review-scope/code-review-scope-findings.md`
+
+## Approach
+
+1. `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)`에 `selectedText: String?` 파라미터를 추가한다.
+2. `enablesReturnKeyAutomatically == false`이면 기존처럼 항상 `true`를 반환한다.
+3. 자동 활성화가 켜져 있으면 before/selected/after 중 하나라도 비어 있지 않을 때 `true`를 반환한다.
+4. `BaseKeyboardViewController.updateReturnButtonEnabled()`에서 `textDocumentProxy.selectedText`를 전달한다.
+5. 기존 정책 테스트 호출부를 새 시그니처로 갱신하고, before/after가 nil 또는 빈 문자열이고 selectedText만 있는 경우 활성화되는 테스트를 추가한다.
+6. finding 처리 후 `dev/active/code-review-scope/code-review-scope-findings.md`의 Track 9 항목을 `Resolved`로 갱신하고 처리/검증 결과를 기록한다.
+
+## Non-Goals
+
+- `currentTextContextSnapshot()`과 `KeyboardTextContextSnapshot`에는 `selectedText`를 섞지 않는다. 이 경로는 undo/redo cursor anchor용이다.
+- `CursorDragAccelerationPolicy.applicableSteps(...)`에는 `selectedText`를 섞지 않는다. 이 경로는 커서 이동 가능 거리 계산용이다.
+- `KeyboardPeriodShortcutPolicy`와 `EnglishKeyboardCoreViewController.updateShiftButton()`은 caret 앞 문맥 기준 기능이므로 현재 구조를 유지한다.
+- 삭제, 반복 삭제, 자동완성 선택 경로는 이미 `selectedText`를 별도로 고려하고 있으므로 이번 수정 범위에서 확장하지 않는다.
+- `KeyboardTextInteractionPolicy.shouldRepeatDelete(...)`의 빈 문자열 정책은 Track 9의 selected text 누락 문제가 아니므로 별도 이슈로 남긴다.
+
+## Risks
+
+- `isReturnButtonEnabled(...)` 호출부가 테스트 외에 추가될 경우 새 파라미터 누락으로 빌드가 실패할 수 있다. `rg -n "isReturnButtonEnabled"`로 전체 호출부를 확인한다.
+- `selectedText`가 iOS 11+ API이지만 프로젝트 최소 버전은 iOS 16+이므로 별도 availability 분기는 필요하지 않다.
+- return 버튼 활성화 상태는 실제 host text field의 `enablesReturnKeyAutomatically`와 proxy 문맥 조합에 의존하므로, 가능하면 실제 입력 필드에서 전체 선택 상태를 수동 확인한다.
+
+## Verification
+
+- 실행한 검증 명령:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/KeyboardPresentationStatePolicyTests
+```
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+- 결과:
+  - 구현 전 focused 테스트는 `extra argument 'selectedText' in call`로 실패해 RED를 확인했다.
+  - 구현 후 focused 테스트는 `TEST SUCCEEDED`로 통과했다.
+  - 전체 `SYKeyboard` 테스트도 `TEST SUCCEEDED`로 통과했다.
+  - 테스트 실행 중 연결된 잠금 기기 관련 `DTDKRemoteDeviceConnection` 경고가 출력됐지만, 시뮬레이터 테스트는 exit code 0으로 완료됐다.
+
+- 수동 확인이 가능하면:
+  - `enablesReturnKeyAutomatically`가 켜진 텍스트 필드에서 텍스트 전체를 선택한다.
+  - before/after 문맥이 비어 있을 수 있는 상태에서 custom keyboard return 버튼이 활성화되는지 확인한다.
+
+## Done Criteria
+
+- `selectedText`만 있는 문맥에서도 return 자동 활성화 정책이 활성화된다.
+- 정책 테스트에 selected text 전용 케이스가 추가되고 통과한다.
+- 전체 `SYKeyboard` 테스트가 통과했다.
+- `dev/active/code-review-scope/code-review-scope-findings.md`에 처리 상태와 검증 결과가 반영된다.

--- a/dev/active/selected-text-return-key/selected-text-return-key-tasks.md
+++ b/dev/active/selected-text-return-key/selected-text-return-key-tasks.md
@@ -1,0 +1,20 @@
+# Selected Text Return Key Tasks
+
+Last Updated: 2026-06-20
+
+## Checklist
+
+- [x] GitHub Issue #85 본문과 댓글을 확인한다.
+- [x] 관련 정책, 컨트롤러, 테스트 파일을 읽는다.
+- [x] SDK 헤더에서 `UITextDocumentProxy.selectedText`와 `enablesReturnKeyAutomatically` 계약을 확인한다.
+- [x] 리뷰 finding의 타당성을 판단한다.
+- [x] 변경 범위를 확정한다.
+- [x] `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)`에 `selectedText` 파라미터를 추가한다.
+- [x] `BaseKeyboardViewController.updateReturnButtonEnabled()`에서 `textDocumentProxy.selectedText`를 전달한다.
+- [x] `KeyboardPresentationStatePolicyTests`에 selected text만 있는 케이스를 추가하고 기존 호출부를 갱신한다.
+- [x] `rg -n "isReturnButtonEnabled"`로 누락 호출부가 없는지 확인한다.
+- [x] focused 정책 테스트를 실행한다.
+- [x] 전체 `SYKeyboard` 테스트를 실행한다.
+- [x] `dev/active/code-review-scope/code-review-scope-findings.md`에 처리 상태와 검증 결과를 반영한다.
+- [x] `git status --short`로 의도하지 않은 변경이 없는지 확인한다.
+- [x] 완료 내용과 검증 결과를 최종 응답에 요약한다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #85
- Parent: #57

<br>

## 📝 작업 내용
- `KeyboardPresentationStatePolicy.isReturnButtonEnabled(...)`에 `selectedText` 문맥을 추가했습니다.
- `BaseKeyboardViewController.updateReturnButtonEnabled()`에서 `textDocumentProxy.selectedText`를 전달하도록 변경했습니다.
- 전체 선택 텍스트만 있는 경우에도 return 자동 활성화 정책이 활성화되는 테스트를 추가했습니다.
- Track 9 처리 결과와 검증 기록을 `dev/active/code-review-scope/code-review-scope-findings.md` 및 `dev/active/selected-text-return-key/` 작업 문서에 반영했습니다.

<br>

## ✅ 검증
- RED 확인: `KeyboardPresentationStatePolicyTests`에 `selectedText` 파라미터와 selected text 전용 케이스를 먼저 추가한 뒤, 기존 production API에서 `extra argument 'selectedText' in call`로 실패 확인
- `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/KeyboardPresentationStatePolicyTests` → `TEST SUCCEEDED`
- `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'` → `TEST SUCCEEDED`
- 실기기 확인: 전체 선택 상태에서 return 키 활성화 동작 정상 확인
- 참고: 테스트 실행 중 연결된 잠금 기기 관련 `DTDKRemoteDeviceConnection` 경고가 출력됐지만, 지정한 시뮬레이터 테스트는 exit code 0으로 완료됐습니다.

<br>
