### PR TITLE
Fix/#91 한글 삭제 상태 중복 축소

### DIFF
--- a/Modules/HangeulKeyboardCore/Domain/HangeulCompositionState.swift
+++ b/Modules/HangeulKeyboardCore/Domain/HangeulCompositionState.swift
@@ -57,6 +57,7 @@ struct HangeulCompositionState {
     private var isPulledFromProtected: Bool = false
     private var shouldSkipNextDeletePanRestore: Bool = false
     private var nextDeletePanRestoreReplacement: Character?
+    private var deleteTouchDownSnapshot: DeleteTouchDownSnapshot?
 
     var text: String {
         return committedBuffer + composingBuffer
@@ -217,26 +218,45 @@ struct HangeulCompositionState {
     mutating func deleteButtonTouchDown(
         using processor: HangeulProcessable
     ) -> HangeulDeleteTouchDownResult {
-        let hadComposingBeforeDelete = !composingBuffer.isEmpty
-        let composingBeforeDelete = composingBuffer
-        let committedBeforeDelete = committedBuffer
         let deletedCharacter = text.last
 
         if let deletedCharacter {
             temporaryDeletedCharacters.append(deletedCharacter)
         }
 
+        beginDeleteButtonTouchDown()
         let transition = delete(using: processor)
-        shouldSkipNextDeletePanRestore = hadComposingBeforeDelete && !composingBuffer.isEmpty
-        nextDeletePanRestoreReplacement = deletePanRestoreReplacementAfterDeleteTouchDown(
-            composingBeforeDelete: composingBeforeDelete,
-            committedBeforeDelete: committedBeforeDelete
-        )
+        endDeleteButtonTouchDown()
 
         return HangeulDeleteTouchDownResult(
             deletedCharacter: deletedCharacter,
             transition: transition
         )
+    }
+
+    mutating func beginDeleteButtonTouchDown() {
+        deleteTouchDownSnapshot = DeleteTouchDownSnapshot(
+            hadComposingBeforeDelete: !composingBuffer.isEmpty,
+            composingBeforeDelete: composingBuffer,
+            committedBeforeDelete: committedBuffer
+        )
+    }
+
+    mutating func endDeleteButtonTouchDown() {
+        guard let snapshot = deleteTouchDownSnapshot else { return }
+
+        shouldSkipNextDeletePanRestore = snapshot.hadComposingBeforeDelete && !composingBuffer.isEmpty
+        nextDeletePanRestoreReplacement = deletePanRestoreReplacementAfterDeleteTouchDown(
+            composingBeforeDelete: snapshot.composingBeforeDelete,
+            committedBeforeDelete: snapshot.committedBeforeDelete
+        )
+        deleteTouchDownSnapshot = nil
+    }
+
+    mutating func cancelDeleteButtonTouchDown() {
+        deleteTouchDownSnapshot = nil
+        shouldSkipNextDeletePanRestore = false
+        nextDeletePanRestoreReplacement = nil
     }
 
     @discardableResult
@@ -369,16 +389,9 @@ struct HangeulCompositionState {
         isPulledFromProtected = false
         shouldSkipNextDeletePanRestore = false
         nextDeletePanRestoreReplacement = nil
+        deleteTouchDownSnapshot = nil
         temporaryDeletedCharacters.removeAll()
         lastInputText = nil
-    }
-
-    mutating func setDeletePanRestorePolicy(
-        shouldSkipNextRestore: Bool,
-        replacement: Character?
-    ) {
-        shouldSkipNextDeletePanRestore = shouldSkipNextRestore
-        nextDeletePanRestoreReplacement = replacement
     }
 
     mutating func setDeleteDragState(
@@ -395,6 +408,12 @@ struct HangeulCompositionState {
         self.nextDeletePanRestoreReplacement = nextDeletePanRestoreReplacement
         protectedCommittedCount = min(protectedCommittedCount, committedBuffer.count)
     }
+}
+
+private struct DeleteTouchDownSnapshot {
+    let hadComposingBeforeDelete: Bool
+    let composingBeforeDelete: String
+    let committedBeforeDelete: String
 }
 
 // MARK: - Private Methods

--- a/Modules/HangeulKeyboardCore/Presentation/ViewController/HangeulKeyboardCoreViewController.swift
+++ b/Modules/HangeulKeyboardCore/Presentation/ViewController/HangeulKeyboardCoreViewController.swift
@@ -29,12 +29,6 @@ open class HangeulKeyboardCoreViewController: BaseKeyboardViewController {
     private var compositionState = HangeulCompositionState()
     /// 글자가 입력되었는지 확인하는 플래그
     private var is글자Input: Bool = false
-    /// 삭제 버튼 touchDown 직전 조합 중인 글자가 있었는지 추적합니다.
-    private var hadComposingBeforeDeleteTouchDown: Bool = false
-    /// 삭제 버튼 touchDown 직전 조합 문자열입니다.
-    private var composingBeforeDeleteTouchDown: String = ""
-    /// 삭제 버튼 touchDown 직전 확정 문자열입니다.
-    private var committedBeforeDeleteTouchDown: String = ""
     /// 한글 오토마타
     private let automata: HangeulAutomataProtocol = HangeulAutomata()
     /// 나랏글 입력기
@@ -171,14 +165,10 @@ open class HangeulKeyboardCoreViewController: BaseKeyboardViewController {
     }
 
     open override func textInteractionWillPerform(button: TextInteractable) {
-        hadComposingBeforeDeleteTouchDown = button is DeleteButton && !composingBuffer.isEmpty
-        composingBeforeDeleteTouchDown = hadComposingBeforeDeleteTouchDown ? composingBuffer : ""
-        committedBeforeDeleteTouchDown = hadComposingBeforeDeleteTouchDown ? committedBuffer : ""
-        if !(button is DeleteButton) {
-            compositionState.setDeletePanRestorePolicy(
-                shouldSkipNextRestore: false,
-                replacement: nil
-            )
+        if button is DeleteButton {
+            compositionState.beginDeleteButtonTouchDown()
+        } else {
+            compositionState.cancelDeleteButtonTouchDown()
         }
         super.textInteractionWillPerform(button: button)
     }
@@ -186,18 +176,9 @@ open class HangeulKeyboardCoreViewController: BaseKeyboardViewController {
     open override func textInteractionDidPerform(button: TextInteractable) {
         super.textInteractionDidPerform(button: button)
         if button is DeleteButton {
-            compositionState.setDeletePanRestorePolicy(
-                shouldSkipNextRestore: hadComposingBeforeDeleteTouchDown && !composingBuffer.isEmpty,
-                replacement: deletePanRestoreReplacementAfterDeleteTouchDown()
-            )
-            hadComposingBeforeDeleteTouchDown = false
-            composingBeforeDeleteTouchDown = ""
-            committedBeforeDeleteTouchDown = ""
+            compositionState.endDeleteButtonTouchDown()
         } else {
-            compositionState.setDeletePanRestorePolicy(
-                shouldSkipNextRestore: false,
-                replacement: nil
-            )
+            compositionState.cancelDeleteButtonTouchDown()
         }
         is글자Input = true
         if composingBuffer.isEmpty {
@@ -392,25 +373,6 @@ private extension HangeulKeyboardCoreViewController {
         updateSpaceButtonImage()
     }
 
-    /// touchDown 삭제가 앞 글자를 재조합한 경우 첫 pan 삭제 때 복구할 원래 글자를 반환합니다.
-    func deletePanRestoreReplacementAfterDeleteTouchDown() -> Character? {
-        let remainingBeforeDelete = String(composingBeforeDeleteTouchDown.dropLast())
-        if remainingBeforeDelete.count == 1,
-           composingBuffer.count == 1,
-           remainingBeforeDelete != composingBuffer {
-            return remainingBeforeDelete.last
-        }
-
-        let consumedCommittedCount = committedBeforeDeleteTouchDown.count - committedBuffer.count
-        guard consumedCommittedCount == 1,
-              composingBuffer.count == 1,
-              let consumedCommitted = committedBeforeDeleteTouchDown.last else {
-            return nil
-        }
-
-        return consumedCommitted
-    }
-    
     /// 모든 버퍼를 초기화합니다.
     func clearAllBuffers() {
         compositionState.clearAllBuffers()

--- a/Modules/SYKeyboardCore/Presentation/View/Components/Overlays/CursorDragIndicatorView.swift
+++ b/Modules/SYKeyboardCore/Presentation/View/Components/Overlays/CursorDragIndicatorView.swift
@@ -21,9 +21,13 @@ enum CursorDragIndicatorEffectFactory {
 /// 커서 드래그 표시 레이어의 SF Symbol 생성 정책
 enum CursorDragIndicatorSymbolFactory {
     static let symbolName = "character.cursor.ibeam"
+    static let deleteSymbolName = "delete.backward"
     static let fallbackSymbolName = "text.cursor"
 
-    static func image() -> UIImage? {
+    static func image(
+        symbolName: String = symbolName,
+        fallbackSymbolName: String = fallbackSymbolName
+    ) -> UIImage? {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: FontSize.overlayLarge, weight: .regular)
         return (UIImage(systemName: symbolName) ?? UIImage(systemName: fallbackSymbolName))?
             .withConfiguration(imageConfig)
@@ -44,13 +48,21 @@ enum CursorDragIndicatorVibrancyEffectFactory {
 /// 커서 드래그가 활성화되었음을 보여주는 overlay
 final class CursorDragIndicatorView: UIView {
 
+    // MARK: - Properties
+
+    private let symbolName: String
+    private let fallbackSymbolName: String
+
     // MARK: - UI Components
 
     private lazy var effectView = UIVisualEffectView(effect: CursorDragIndicatorEffectFactory.effect())
     private lazy var vibrancyView = UIVisualEffectView(effect: CursorDragIndicatorVibrancyEffectFactory.effect())
-    private let imageView: UIImageView = {
+    private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = CursorDragIndicatorSymbolFactory.image()
+        imageView.image = CursorDragIndicatorSymbolFactory.image(
+            symbolName: symbolName,
+            fallbackSymbolName: fallbackSymbolName
+        )
         imageView.tintColor = .secondaryLabel
         imageView.contentMode = .center
 
@@ -59,7 +71,13 @@ final class CursorDragIndicatorView: UIView {
 
     // MARK: - Initializer
 
-    override init(frame: CGRect) {
+    init(
+        symbolName: String = CursorDragIndicatorSymbolFactory.symbolName,
+        fallbackSymbolName: String = CursorDragIndicatorSymbolFactory.fallbackSymbolName,
+        frame: CGRect = .zero
+    ) {
+        self.symbolName = symbolName
+        self.fallbackSymbolName = fallbackSymbolName
         super.init(frame: frame)
         setupUI()
     }

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -184,6 +184,14 @@ open class BaseKeyboardViewController: UIInputViewController {
         view.isHidden = true
         return view
     }()
+    /// 삭제 버튼 드래그 활성 상태를 표시하는 overlay
+    private lazy var deleteDragIndicatorView: CursorDragIndicatorView = {
+        let view = CursorDragIndicatorView(
+            symbolName: CursorDragIndicatorSymbolFactory.deleteSymbolName
+        )
+        view.isHidden = true
+        return view
+    }()
 
     // MARK: - Initializer
 
@@ -680,14 +688,16 @@ private extension BaseKeyboardViewController {
     }
 
     func setCursorDragOverlays() {
-        keyboardView.addSubview(cursorDragIndicatorView)
-        cursorDragIndicatorView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            cursorDragIndicatorView.topAnchor.constraint(equalTo: keyboardHStackView.topAnchor),
-            cursorDragIndicatorView.leadingAnchor.constraint(equalTo: keyboardHStackView.leadingAnchor),
-            cursorDragIndicatorView.trailingAnchor.constraint(equalTo: keyboardHStackView.trailingAnchor),
-            cursorDragIndicatorView.bottomAnchor.constraint(equalTo: keyboardHStackView.bottomAnchor)
-        ])
+        [cursorDragIndicatorView, deleteDragIndicatorView].forEach {
+            keyboardView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                $0.topAnchor.constraint(equalTo: keyboardHStackView.topAnchor),
+                $0.leadingAnchor.constraint(equalTo: keyboardHStackView.leadingAnchor),
+                $0.trailingAnchor.constraint(equalTo: keyboardHStackView.trailingAnchor),
+                $0.bottomAnchor.constraint(equalTo: keyboardHStackView.bottomAnchor)
+            ])
+        }
     }
 
     func setKeyboardHeight() {
@@ -1401,6 +1411,7 @@ extension BaseKeyboardViewController: TextInteractionGestureControllerDelegate {
     }
 
     final func deleteButtonPanning(_ controller: TextInteractionGestureController, to direction: PanDirection) {
+        showDeleteDragOverlays()
         switch direction {
         case .left:
             performDeleteButtonPanDeleteIfPossible()
@@ -1412,6 +1423,7 @@ extension BaseKeyboardViewController: TextInteractionGestureControllerDelegate {
     }
 
     final func deleteButtonPanStopped(_ controller: TextInteractionGestureController) {
+        hideDeleteDragOverlays()
         tempDeletedCharacters.removeAll()
         deleteButtonPanDidStop()
         logger.debug("임시 삭제 내용 저장 변수 초기화")
@@ -1459,6 +1471,15 @@ private extension BaseKeyboardViewController {
 
     func hideCursorDragOverlays() {
         cursorDragIndicatorView.isHidden = true
+    }
+
+    func showDeleteDragOverlays() {
+        deleteDragIndicatorView.isHidden = false
+        keyboardView.bringSubviewToFront(deleteDragIndicatorView)
+    }
+
+    func hideDeleteDragOverlays() {
+        deleteDragIndicatorView.isHidden = true
     }
 
     func moveCursorIfPossible(to direction: PanDirection, steps: Int) -> Int {

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -1466,7 +1466,6 @@ extension BaseKeyboardViewController: TextInteractionGestureControllerDelegate {
 private extension BaseKeyboardViewController {
     func showCursorDragOverlays() {
         cursorDragIndicatorView.isHidden = false
-        keyboardView.bringSubviewToFront(cursorDragIndicatorView)
     }
 
     func hideCursorDragOverlays() {
@@ -1475,7 +1474,6 @@ private extension BaseKeyboardViewController {
 
     func showDeleteDragOverlays() {
         deleteDragIndicatorView.isHidden = false
-        keyboardView.bringSubviewToFront(deleteDragIndicatorView)
     }
 
     func hideDeleteDragOverlays() {

--- a/SYKeyboardTests/Domain/HangeulCompositionStateTests.swift
+++ b/SYKeyboardTests/Domain/HangeulCompositionStateTests.swift
@@ -105,6 +105,26 @@ struct HangeulCompositionStateTests {
         #expect(state.temporaryDeletedCharacters == ["돈"])
     }
 
+    @Test("delete touchDown 경계 기록은 controller 삭제 흐름의 첫 pan 복구 정책을 보존함")
+    func testDeleteTouchDown경계기록_첫Pan복구정책() {
+        var state = HangeulCompositionState()
+        let processor = DubeolsikProcessor(automata: HangeulAutomata())
+
+        ["ㄷ", "ㅗ", "ㅇ", "ㅎ", "ㅐ", "ㅁ", "ㅜ", "ㄹ", "ㄱ", "ㅗ", "ㅏ"].forEach {
+            _ = state.input($0, using: processor)
+        }
+
+        state.beginDeleteButtonTouchDown()
+        let delete = state.delete(using: processor)
+        state.endDeleteButtonTouchDown()
+        let panDelete = state.deleteButtonPanDelete(using: processor)
+
+        #expect(delete.proxyEdit == .replace(deleteCount: 1, insertText: "고"))
+        #expect(state.temporaryDeletedCharacters.isEmpty)
+        #expect(panDelete?.character == "고")
+        #expect(panDelete?.shouldRestore == false)
+    }
+
     @Test("delete pan 종료는 임시 복구 상태만 초기화함")
     func testDeletePan종료_임시복구상태초기화() {
         var state = HangeulCompositionState()

--- a/SYKeyboardTests/Domain/SuggestionControllerPreparationTests.swift
+++ b/SYKeyboardTests/Domain/SuggestionControllerPreparationTests.swift
@@ -137,6 +137,27 @@ struct SuggestionControllerPreparationTests {
         #expect(delegate.updates.last?.suggestions == ["오늘", "내일"])
         #expect(delegate.updateIsMainThread.last == true)
     }
+
+    @Test("후보 초기화 후 n-gram 로딩 완료는 마지막 후보를 다시 갱신하지 않음")
+    func test후보초기화후_NGram로딩완료_후보갱신없음() {
+        let factory = CountingSuggestionEngineFactory()
+        let delegate = RecordingSuggestionControllerDelegate()
+        let controller = SuggestionController(
+            language: "ko-KR",
+            engineFactory: factory.makeFactory()
+        )
+        controller.delegate = delegate
+        controller.isPredictiveTextEnabled = true
+
+        controller.updateSuggestions(for: "")
+        controller.clearSuggestions()
+        let updateCountAfterClear = delegate.updates.count
+
+        factory.lastNGramProvider?.completeLoad(suggestions: ["오늘", "내일"])
+
+        #expect(delegate.updates.count == updateCountAfterClear)
+        #expect(delegate.updates.last?.suggestions == [])
+    }
 }
 
 private final class CountingSuggestionEngineFactory {

--- a/SYKeyboardTests/Domain/SuggestionControllerTextReplacementTests.swift
+++ b/SYKeyboardTests/Domain/SuggestionControllerTextReplacementTests.swift
@@ -153,6 +153,31 @@ struct SuggestionControllerTextReplacementTests {
         #expect(restore == nil)
     }
 
+    @Test("대치 복구 직후 같은 단축어는 한 번만 재대치를 건너뜀")
+    func test대치복구직후_같은단축어_재대치한번건너뜀() {
+        let controller = makeController(
+            entries: [
+                TextReplacementEntry(userInput: "id", documentText: "identifier")
+            ]
+        )
+        controller.isTextReplacementEnabled = true
+        controller.prepareLexiconEngineIfNeeded()
+
+        _ = controller.attemptTextReplacement(baseText: "id")
+        let restore = controller.attemptRestoreReplacement(
+            inputBuffer: "identifier",
+            documentContextBeforeInput: "identifier",
+            selectedText: nil
+        )
+
+        #expect(restore?.insertText == "id")
+        #expect(controller.attemptTextReplacement(baseText: "id") == nil)
+
+        let replacement = controller.attemptTextReplacement(baseText: "id")
+        #expect(replacement?.deleteCount == 2)
+        #expect(replacement?.insertText == "identifier")
+    }
+
     private func makeController(entries: [TextReplacementEntry]) -> SuggestionController {
         let provider = StubLexiconSuggestionProvider(entries: entries)
         let factory = SuggestionControllerEngineFactory(

--- a/SYKeyboardTests/Utils/CursorDragOverlayTests.swift
+++ b/SYKeyboardTests/Utils/CursorDragOverlayTests.swift
@@ -30,6 +30,12 @@ struct CursorDragOverlayTests {
         #expect(CursorDragIndicatorSymbolFactory.symbolName == "character.cursor.ibeam")
     }
 
+    @Test("delete indicator symbol은 delete backward를 사용")
+    func testDeleteIndicatorSymbol_deleteBackward() {
+        #expect(CursorDragIndicatorSymbolFactory.deleteSymbolName == "delete.backward")
+        #expect(CursorDragIndicatorSymbolFactory.image(symbolName: "delete.backward") != nil)
+    }
+
     @Test("indicator symbol image는 구형 OS에서도 비어 있지 않음")
     func testIndicatorSymbolImage_존재() {
         #expect(CursorDragIndicatorSymbolFactory.image() != nil)

--- a/SYKeyboardTests/Utils/KeyboardSuggestionSelectionPolicyTests.swift
+++ b/SYKeyboardTests/Utils/KeyboardSuggestionSelectionPolicyTests.swift
@@ -162,6 +162,18 @@ struct KeyboardSuggestionSelectionPolicyTests {
         )
     }
 
+    @Test("커서 앞 문맥 제한은 nil을 빈 문자열로 처리하고 256자 suffix만 유지")
+    func test커서앞문맥제한_nil과길이제한() {
+        let droppedPrefix = String(repeating: "가", count: 3)
+        let retainedContext = String(repeating: "나", count: KeyboardTextContextNavigator.maximumCursorRestoreDistance)
+
+        #expect(KeyboardSuggestionSelectionPolicy.limitedDocumentContextBeforeInput(nil) == "")
+        #expect(
+            KeyboardSuggestionSelectionPolicy.limitedDocumentContextBeforeInput(droppedPrefix + retainedContext)
+            == retainedContext
+        )
+    }
+
     @Test("lexicon은 텍스트 대치나 자동완성 중 하나라도 켜진 경우 로드")
     func testLexicon로딩조건() {
         #expect(

--- a/SYKeyboardTests/Utils/KeyboardUndoRedoManagerTests.swift
+++ b/SYKeyboardTests/Utils/KeyboardUndoRedoManagerTests.swift
@@ -376,4 +376,42 @@ struct KeyboardUndoRedoSessionTests {
         #expect(session.canUndo == true)
         #expect(session.canApplyUndo(from: unreachable) == false)
     }
+
+    @Test("undo/redo 적용 중 text change는 history를 무효화하지 않음")
+    func testApplyingEdit중_TextChange_History유지() {
+        let session = KeyboardUndoRedoSession()
+        let firstInput = NSObject()
+        let secondInput = NSObject()
+        let firstID = ObjectIdentifier(firstInput)
+        let secondID = ObjectIdentifier(secondInput)
+        let source = KeyboardTextContextSnapshot(beforeInput: "abc", afterInput: "")
+        let changed = KeyboardTextContextSnapshot(beforeInput: "xyz", afterInput: "")
+
+        session.record(
+            deletedText: "",
+            insertedText: "d",
+            targetContext: source,
+            shouldDeferCommit: { false },
+            debouncedCommitDidFinish: {}
+        )
+        session.commitPendingGroup(shouldDeferCommit: false)
+        session.prepareForTextWillChange(inputIdentifier: firstID, context: source)
+        #expect(
+            session.shouldInvalidateAfterTextChange(
+                inputIdentifier: firstID,
+                currentContext: source
+            ) == false
+        )
+
+        let didApply = session.performApplyingEdit {
+            session.prepareForTextWillChange(inputIdentifier: firstID, context: source)
+            return session.shouldInvalidateAfterTextChange(
+                inputIdentifier: secondID,
+                currentContext: changed
+            ) == false
+        }
+
+        #expect(didApply)
+        #expect(session.canUndo)
+    }
 }

--- a/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-context.md
+++ b/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-context.md
@@ -1,0 +1,182 @@
+# Hangeul Controller Domain Test Stabilization Context
+
+Last Updated: 2026-06-26
+
+## Relevant Files
+
+- `Modules/HangeulKeyboardCore/Domain/HangeulCompositionState.swift`: 한글 입력, 스페이스, 삭제, 반복 입력/삭제, delete pan restore 상태 전이를 담당한다.
+- `Modules/HangeulKeyboardCore/Presentation/ViewController/HangeulKeyboardCoreViewController.swift`: 한글 키보드 controller이며 `HangeulCompositionState` 전이를 `textDocumentProxy` 편집으로 적용한다.
+- `SYKeyboardTests/Domain/HangeulCompositionStateTests.swift`: `HangeulCompositionState`의 입력/삭제/반복 삭제/delete pan 상태를 검증한다.
+- `SYKeyboardTests/Utils/KeyboardControllerSimulator.swift`: controller의 핵심 상태 전이를 테스트하기 위한 helper다. 현재 실제 상태 전이는 `HangeulCompositionState`에 위임한다.
+- `Modules/SYKeyboardCore/Domain/SuggestionController.swift`: text replacement, predictive text, n-gram 후보 갱신을 담당한다.
+- `Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardSuggestionSelectionPolicy.swift`: suggestion 선택/갱신 조건을 UI와 분리한 policy다.
+- `Modules/SYKeyboardCore/Presentation/Utils/KeyboardUndoRedoManager.swift`: undo/redo edit, cursor context matching, session 지연 commit과 적용 중 상태를 담당한다.
+- `SYKeyboardTests/Domain/SuggestionControllerTextReplacementTests.swift`: text replacement와 복구 history를 검증한다.
+- `SYKeyboardTests/Domain/SuggestionControllerPreparationTests.swift`: suggestion engine 지연 준비와 n-gram load callback을 검증한다.
+- `SYKeyboardTests/Utils/KeyboardSuggestionSelectionPolicyTests.swift`: suggestion selection/update policy를 검증한다.
+- `SYKeyboardTests/Utils/KeyboardUndoRedoManagerTests.swift`: undo/redo manager, cursor navigator, session 일부를 검증한다.
+
+## Facts Checked
+
+- GitHub Issue #91은 2026-06-22 03:06:20 UTC에 생성되었고 현재 open 상태다.
+- Issue #91은 `BaseKeyboardViewController` 추가 분해를 이번 범위에서 제외한다.
+- Issue #91은 한글 입력/삭제/조합 동작 변경을 금지하고, 변경이 필요하면 별도 fix/feature 이슈로 분리하도록 적고 있다.
+- `HangeulCompositionState`에는 `temporaryDeletedCharacters`, `shouldSkipNextDeletePanRestore`, `nextDeletePanRestoreReplacement`가 있다.
+- `HangeulCompositionState.deleteButtonTouchDown(using:)`은 삭제 전 composing/committed 상태를 내부에서 캡처하고 `deletePanRestoreReplacementAfterDeleteTouchDown(composingBeforeDelete:committedBeforeDelete:)`로 replacement를 계산한다.
+- `HangeulKeyboardCoreViewController`에도 `hadComposingBeforeDeleteTouchDown`, `composingBeforeDeleteTouchDown`, `committedBeforeDeleteTouchDown`가 남아 있다.
+- `HangeulKeyboardCoreViewController.textInteractionWillPerform(button:)`는 delete touchDown 직전 상태를 저장하고, delete가 아닌 버튼이면 delete pan restore policy를 초기화한다.
+- `HangeulKeyboardCoreViewController.textInteractionDidPerform(button:)`는 delete 버튼일 때 `compositionState.setDeletePanRestorePolicy(...)`를 다시 호출한다.
+- `KeyboardControllerSimulator`는 `HangeulCompositionState`를 내부에 두며 `setDeleteDragStateForTesting(...)` 같은 테스트 helper API를 노출한다.
+- `SuggestionControllerTextReplacementTests`, `SuggestionControllerPreparationTests`, `KeyboardSuggestionSelectionPolicyTests`, `KeyboardUndoRedoManagerTests`는 이미 존재한다.
+- `KeyboardUndoRedoSession.performApplyingEdit(_:)`와 `shouldInvalidateAfterTextChange(...)`는 적용 중 text change 무효화 방지를 위한 hook을 가진다.
+- 구현 후 `HangeulKeyboardCoreViewController`의 `hadComposingBeforeDeleteTouchDown`, `composingBeforeDeleteTouchDown`, `committedBeforeDeleteTouchDown`는 제거됐다.
+- 구현 후 `HangeulCompositionState`는 delete touchDown snapshot lifecycle을 내부에서 관리한다.
+- `deleteBackward()`와 delete pan proxy edit 적용 경로는 변경하지 않았다.
+
+## Evaluation Notes
+
+- 이슈의 핵심 방향은 타당하다.
+  - 근거: 상태 전이를 이미 분리한 `HangeulCompositionState`가 있으므로 `BaseKeyboardViewController`를 더 쪼개기보다 남은 중복 상태를 줄이는 편이 범위가 작다.
+- 단, controller 상태를 무리하게 제거하면 버튼 gesture lifecycle을 바꿀 수 있다.
+  - 구현 전 `TextInteractionGestureController`와 `BaseKeyboardViewController.performTextInteraction(for:)` 호출 순서를 함께 확인해야 한다.
+- suggestion/undo 테스트 보강은 타당하지만 이미 있는 테스트와 중복되면 유지 비용만 늘어난다.
+  - 새 테스트는 “기존 테스트가 말하지 않는 경계 조건”만 추가한다.
+- `KeyboardControllerSimulator`를 삭제하는 것은 현재 이슈 문구와 맞지 않는다.
+  - 이슈는 simulator 제거가 아니라 얇게 유지하거나 역할을 갱신하는 방향이다.
+
+## Decisions
+
+- 작업 이름은 `hangeul-controller-domain-test-stabilization`으로 둔다.
+- 이번 작업은 신규 큰 coordinator, proxy adapter, full suggestion coordinator 추출을 하지 않는다.
+- 한글 동작 변경이 감지되면 리팩터링 범위에서 처리하지 않고 별도 이슈로 분리한다.
+- baseline 테스트를 먼저 실행하고, 실패가 있으면 구현 전에 현재 실패인지 변경으로 인한 실패인지 구분한다.
+- Xcode 샌드박스 권한 오류가 발생하면 같은 명령을 권한 있는 실행으로 재시도하고, 최종 문서에는 샌드박스 실패와 권한 있는 실행 결과를 구분한다.
+- Production 코드의 기능 변경 여지는 삭제 touchDown/pan/restore 경계에만 있었다. 이를 줄이기 위해 버튼 이벤트 순서와 proxy edit 적용 코드는 유지하고, snapshot 보관 위치만 controller에서 domain state로 옮겼다.
+- `KeyboardControllerSimulator`는 이미 `HangeulCompositionState`를 쓰는 helper이므로 이번 작업에서는 production/test helper 구조를 더 흔들지 않았다.
+- `SuggestionControllerPreparationTests`에 처음 추가했던 suspend 중 n-gram callback 테스트는 grouped 실행에서 불안정해 제거하고, 동기적인 clear 후 callback 경계 테스트로 대체했다.
+
+## Open Questions
+
+- 실제 입력 앱에서 삭제 버튼 touchDown, 왼쪽 pan 삭제, 오른쪽 pan restore를 수동으로 다시 확인하면 더 좋다.
+- `HangeulKeyboard` scheme 단독 빌드는 샌드박스 CoreSimulator 실패와 권한 있는 실행 승인 거절로 별도 성공 결과를 얻지 못했다.
+
+## Verification Notes
+
+- 문서 작성 전 확인 명령:
+
+```sh
+git status --short
+```
+
+  - 결과: 출력 없음. 작업 전 워크트리는 깨끗했다.
+
+```sh
+gh issue view 91 --repo SNMac/SYKeyboard --json number,title,state,author,createdAt,updatedAt,body,labels,comments
+```
+
+  - 결과: Issue #91 본문과 체크리스트를 확인했다. comments는 비어 있었다.
+
+```sh
+rg --files | rg 'HangeulCompositionState|HangeulKeyboardCoreViewController|KeyboardControllerSimulator|SuggestionController|KeyboardSuggestionSelectionPolicy|KeyboardUndoRedo'
+```
+
+  - 결과: 이 문서의 Relevant Files에 적은 파일들을 확인했다.
+
+```sh
+sed -n '1,260p' Modules/HangeulKeyboardCore/Domain/HangeulCompositionState.swift
+sed -n '260,620p' Modules/HangeulKeyboardCore/Domain/HangeulCompositionState.swift
+sed -n '1,260p' Modules/HangeulKeyboardCore/Presentation/ViewController/HangeulKeyboardCoreViewController.swift
+sed -n '260,620p' Modules/HangeulKeyboardCore/Presentation/ViewController/HangeulKeyboardCoreViewController.swift
+```
+
+  - 결과: delete touchDown/pan/restore 관련 상태가 state와 controller 양쪽에 남아 있음을 확인했다.
+
+```sh
+sed -n '1,260p' SYKeyboardTests/Utils/KeyboardControllerSimulator.swift
+sed -n '1,360p' SYKeyboardTests/Domain/HangeulCompositionStateTests.swift
+```
+
+  - 결과: simulator는 `HangeulCompositionState`를 공유하고, state tests에는 delete pan 중복 방지와 pan 종료 초기화 테스트가 이미 있음을 확인했다.
+
+```sh
+sed -n '1,290p' SYKeyboardTests/Utils/KeyboardSuggestionSelectionPolicyTests.swift
+sed -n '1,230p' SYKeyboardTests/Domain/SuggestionControllerTextReplacementTests.swift
+sed -n '1,260p' SYKeyboardTests/Domain/SuggestionControllerPreparationTests.swift
+sed -n '1,460p' SYKeyboardTests/Utils/KeyboardUndoRedoManagerTests.swift
+```
+
+  - 결과: suggestion/undo 도메인 테스트가 이미 존재하므로 중복 없는 경계 보강이 필요하다고 판단했다.
+
+- 이 문서 작성 단계에서는 Xcode 테스트를 실행하지 않았다. 테스트 실행은 구현 작업의 baseline 단계로 남긴다.
+
+- 구현 전 baseline:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/HangeulCompositionStateTests
+```
+
+  - 결과: 통과.
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/KeyboardSuggestionSelectionPolicyTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerTextReplacementTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerPreparationTests \
+  -only-testing:SYKeyboardTests/KeyboardUndoRedoManagerTests
+```
+
+  - 결과: 통과.
+
+- 구현 후 targeted 검증:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/HangeulCompositionStateTests \
+  -only-testing:SYKeyboardTests/HangeulDeleteButtonDragControllerTests
+```
+
+  - 결과: 통과.
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/KeyboardSuggestionSelectionPolicyTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerTextReplacementTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerPreparationTests \
+  -only-testing:SYKeyboardTests/KeyboardUndoRedoManagerTests
+```
+
+  - 결과: 통과.
+
+- 구현 후 전체 검증:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+  - 결과: 통과. `** TEST SUCCEEDED **`
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme HangeulKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+  - 결과: 샌드박스에서 `CoreSimulatorService connection became invalid`로 실패.
+  - 권한 있는 재실행은 Crashlytics 외부 전송 가능성 때문에 자동 승인 거절됨.

--- a/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-context.md
+++ b/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-context.md
@@ -180,3 +180,11 @@ xcodebuild build \
 
   - 결과: 샌드박스에서 `CoreSimulatorService connection became invalid`로 실패.
   - 권한 있는 재실행은 Crashlytics 외부 전송 가능성 때문에 자동 승인 거절됨.
+
+- 사용자 실기기 수동 확인:
+
+```text
+한글 키보드 실제 입력 앱에서 삭제 버튼 단일 탭, 왼쪽 pan 삭제, 오른쪽 pan restore, 반복 삭제 후 조합 복원 흐름 확인
+```
+
+  - 결과: 정상 동작 확인.

--- a/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-plan.md
+++ b/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-plan.md
@@ -1,0 +1,153 @@
+# Hangeul Controller Domain Test Stabilization Plan
+
+Last Updated: 2026-06-26
+
+## Goal
+
+- GitHub Issue #91의 범위에 따라 `BaseKeyboardViewController` 대분해 대신 한글 controller/simulator 중복 축소와 suggestion/undo 도메인 테스트 안정화를 진행한다.
+- 한글 입력, 삭제, 조합의 사용자 동작은 바꾸지 않고, 변경이 필요해 보이면 별도 fix/feature 이슈로 분리한다.
+
+## Current State
+
+- Issue #91은 열려 있으며 제목은 `[Refactor] 한글 controller 중복 축소와 suggestion/undo 도메인 테스트 안정화`다.
+- 이슈의 방향은 현재 코드 기준으로 대체로 타당하며, 작업 결과 production 코드의 의도된 기능 변경 없이 controller의 중복 상태만 줄였다.
+  - `HangeulCompositionState`는 이미 한글 조합/삭제 상태 전이를 공유하고 있다.
+  - `KeyboardControllerSimulator`는 `HangeulCompositionState`를 사용하지만 controller 시뮬레이션 helper 역할과 테스트용 상태 세팅 API를 함께 가진다.
+  - `HangeulKeyboardCoreViewController`에는 삭제 touchDown 직전 상태(`hadComposingBeforeDeleteTouchDown`, `composingBeforeDeleteTouchDown`, `committedBeforeDeleteTouchDown`)를 보관하고 restore replacement를 계산하는 코드가 남아 있다.
+  - `SuggestionController`, `KeyboardSuggestionSelectionPolicy`, `KeyboardUndoRedoManager`, `KeyboardUndoRedoSession` 단위 테스트가 이미 있으므로 보강은 기존 테스트와 중복되지 않는 경계 위주로 해야 한다.
+- 구현 후 상태:
+  - 삭제 touchDown 전 상태 snapshot은 `HangeulCompositionState`가 소유한다.
+  - `HangeulKeyboardCoreViewController`는 버튼 lifecycle에서 `beginDeleteButtonTouchDown()`, `endDeleteButtonTouchDown()`, `cancelDeleteButtonTouchDown()`만 호출한다.
+  - `deleteBackward()`, `deleteButtonPanDeleteText()`, `deleteButtonPanRestoreText()`, undo/redo commit 호출 순서는 바꾸지 않았다.
+  - `KeyboardControllerSimulator`는 이미 `HangeulCompositionState`를 사용하므로 추가 production 변경 없이 역할을 유지했다.
+- 관련 파일:
+  - `Modules/HangeulKeyboardCore/Domain/HangeulCompositionState.swift`
+  - `Modules/HangeulKeyboardCore/Presentation/ViewController/HangeulKeyboardCoreViewController.swift`
+  - `SYKeyboardTests/Domain/HangeulCompositionStateTests.swift`
+  - `SYKeyboardTests/Utils/KeyboardControllerSimulator.swift`
+  - `Modules/SYKeyboardCore/Domain/SuggestionController.swift`
+  - `Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardSuggestionSelectionPolicy.swift`
+  - `Modules/SYKeyboardCore/Presentation/Utils/KeyboardUndoRedoManager.swift`
+  - `SYKeyboardTests/Domain/SuggestionControllerTextReplacementTests.swift`
+  - `SYKeyboardTests/Domain/SuggestionControllerPreparationTests.swift`
+  - `SYKeyboardTests/Utils/KeyboardSuggestionSelectionPolicyTests.swift`
+  - `SYKeyboardTests/Utils/KeyboardUndoRedoManagerTests.swift`
+
+## Technical Evaluation
+
+- 타당함: `KeyboardControllerSimulator` 제거보다 얇게 유지하는 방향.
+  - 근거: simulator는 실제 상태 전이를 `HangeulCompositionState`에 위임하고 있어 독립 구현체는 아니다.
+  - 주의: 테스트 helper가 controller의 두 번째 구현체처럼 커지는 것은 막아야 한다.
+- 타당함: 삭제 touchDown/pan/restore bookkeeping을 `HangeulCompositionState` 중심으로 정리하는 방향.
+  - 근거: `HangeulCompositionState.deleteButtonTouchDown(using:)`은 이미 touchDown 전 상태를 내부에서 기록해 restore replacement를 계산한다.
+  - 근거: controller에는 같은 목적의 touchDown 전 상태 저장과 `deletePanRestoreReplacementAfterDeleteTouchDown()`가 별도로 남아 있다.
+  - 주의: 실제 버튼 이벤트 타이밍은 변경하지 않는다.
+- 타당함: suggestion 흐름을 `BaseKeyboardViewController` 직접 테스트보다 domain/policy 테스트로 보강하는 방향.
+  - 근거: `BaseKeyboardViewController`는 `KeyboardSuggestionSelectionPolicy`와 `SuggestionController`를 통해 selection/update 조건을 이미 분리한다.
+  - 주의: UIKit controller 통합 동작이 필요한 회귀는 별도 integration 검증으로 다뤄야 한다.
+- 타당함: undo/redo 흐름을 `KeyboardUndoRedoSession`/manager 단위에서 먼저 검증하는 방향.
+  - 근거: 지연 확정, cursor context, 적용 중 history 무효화 방지는 UI보다 session/manager 책임에 가깝다.
+  - 주의: `isApplyingEdit` 중 record 방지는 현재 `BaseKeyboardViewController` 호출 경로까지 함께 확인해야 한다.
+- 타당함: base coordinator 대분해, `textDocumentProxy` adapter, full suggestion coordinator 추출을 제외하는 범위.
+  - 근거: 이번 이슈의 직접 목표는 회귀 위험이 높은 입력 동작 변경이 아니라 중복 축소와 테스트 안정화다.
+
+## Approach
+
+1. Baseline 확인
+   - 작업 전 `git status --short`로 변경 범위를 확인한다.
+   - targeted 한글 composition/simulator/controller 관련 테스트를 먼저 실행한다.
+2. 한글 삭제 상태 전이 보강
+   - `HangeulCompositionStateTests`에 delete touchDown 후 첫 pan restore 정책 회귀 테스트를 추가한다.
+   - controller가 별도로 보관하는 touchDown 전 상태를 `HangeulCompositionState.deleteButtonTouchDown(using:)` 경로로 대체할 수 있는지 작은 단위로 검토한다.
+   - 대체 시 `textInteractionWillPerform`, `textInteractionDidPerform`, `deleteBackward`, `deleteButtonPanDeleteText`, `deleteButtonPanRestoreText` 이벤트 순서를 유지한다.
+3. Simulator 역할 축소
+   - `KeyboardControllerSimulator`가 테스트 helper임을 문서화하거나, controller 전용 상태 세팅 API를 `HangeulCompositionState` 중심 테스트로 이동한다.
+   - simulator에서 실제 controller 상태 전이를 재구현하는 코드가 생기지 않도록 한다.
+4. Suggestion domain/policy 테스트 보강
+   - `SuggestionControllerTextReplacementTests`는 선택 텍스트, 커서 앞 context, replacement history 경계를 중심으로 빠진 케이스만 추가한다.
+   - `SuggestionControllerPreparationTests`는 suspend 해제, 엔진 준비, n-gram callback 경계 중 기존 테스트와 중복되지 않는 케이스를 추가한다.
+   - `KeyboardSuggestionSelectionPolicyTests`는 selection/update/base text 조건의 빈 문자열, 다중 공백, nil context 경계를 보강한다.
+5. Undo/redo domain 테스트 보강
+   - `KeyboardUndoRedoManagerTests`에 pending group 지연 확정, cursor context 적용 가능성, undo/redo 적용 중 history 무효화 방지 경계를 추가한다.
+   - session 테스트에서 `performApplyingEdit(_:)` 중 `shouldInvalidateAfterTextChange`가 false를 유지하는지 검증한다.
+6. 검증
+   - targeted 테스트를 먼저 통과시킨 뒤 전체 `SYKeyboard` 테스트와 `HangeulKeyboard` scheme 빌드를 실행한다.
+
+## Risks
+
+- 한글 삭제 touchDown/pan/restore는 버튼 이벤트 순서, 반복 삭제, 임시 복구 stack과 맞물려 회귀 위험이 높다.
+- `HangeulCompositionState`로 상태를 옮길 때 controller의 `deleteBackwardWillPerform()` undo/redo commit 타이밍을 바꾸면 기존 undo grouping이 달라질 수 있다.
+- suggestion 테스트를 과도하게 UI controller 쪽으로 확장하면 brittle test가 될 수 있다.
+- undo/redo session 테스트는 debounce timer가 `RunLoop.main`에 의존하므로 비동기 테스트가 불안정해질 수 있다. 가능한 한 직접 commit API나 짧은 session 단위 검증을 우선한다.
+
+## Verification
+
+작업 전 baseline:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/HangeulCompositionStateTests
+```
+
+결과: 통과.
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/KeyboardSuggestionSelectionPolicyTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerTextReplacementTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerPreparationTests \
+  -only-testing:SYKeyboardTests/KeyboardUndoRedoManagerTests
+```
+
+결과: 통과.
+
+작업 중 TDD red:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/HangeulCompositionStateTests/testDeleteTouchDown경계기록_첫Pan복구정책
+```
+
+결과: `HangeulCompositionState`에 `beginDeleteButtonTouchDown`/`endDeleteButtonTouchDown`가 없어 컴파일 실패했다. 이후 구현으로 green 전환했다.
+
+작업 후 전체 검증:
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 통과. `** TEST SUCCEEDED **`
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme HangeulKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 샌드박스에서 `CoreSimulatorService connection became invalid`로 실패했다. 권한 있는 재실행은 Crashlytics dSYM/build metadata 외부 전송 가능성 때문에 자동 승인 거절됨. 단, 직전 전체 `SYKeyboard` 테스트에서 `HangeulKeyboard` dependency 빌드와 테스트 실행은 통과했다.
+
+필요 시 수동 확인:
+
+- 실제 입력 앱에서 한글 키보드를 열고 삭제 버튼 touchDown, 왼쪽 pan 삭제, 오른쪽 pan restore, 반복 삭제 종료 후 조합 복원 흐름을 확인한다.
+
+## Done Criteria
+
+- `HangeulCompositionStateTests`가 delete touchDown 후 첫 pan restore 정책을 명시적으로 검증한다.
+- `HangeulKeyboardCoreViewController`의 삭제 touchDown/pan/restore 상태 관리 중 중복된 부분이 줄거나, 옮기지 않는 이유가 문서화된다.
+- `KeyboardControllerSimulator`가 테스트 helper 역할을 넘어서지 않도록 정리된다.
+- suggestion/undo domain 테스트가 기존 케이스와 중복되지 않는 경계를 보강한다.
+- targeted 테스트, 전체 `SYKeyboard` 테스트, `HangeulKeyboard` build 결과가 기록된다.
+- 한글 입력/삭제/조합 사용자 동작 변경이 없다.

--- a/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-tasks.md
+++ b/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-tasks.md
@@ -23,6 +23,7 @@ Last Updated: 2026-06-26
 - [x] 전체 `SYKeyboard` 테스트를 실행한다.
 - [ ] `HangeulKeyboard` scheme 빌드를 확인한다. 샌드박스 CoreSimulator 실패, 권한 있는 재실행은 Crashlytics 외부 전송 가능성으로 자동 승인 거절.
 - [x] `git status --short`로 의도하지 않은 변경이 없는지 확인한다.
+- [x] 실제 키보드 삭제 제스처 흐름을 사용자 실기기에서 확인한다.
 - [ ] 완료 내용과 검증 결과를 최종 응답에 요약한다.
 
 ## Baseline Commands

--- a/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-tasks.md
+++ b/dev/active/hangeul-controller-domain-test-stabilization/hangeul-controller-domain-test-stabilization-tasks.md
@@ -1,0 +1,67 @@
+# Hangeul Controller Domain Test Stabilization Tasks
+
+Last Updated: 2026-06-26
+
+## Checklist
+
+- [x] Issue #91 본문과 체크리스트를 확인한다.
+- [x] 작업 전 `git status --short`로 워크트리 상태를 확인한다.
+- [x] `dev/README.md`와 `dev/templates/` 문서 규칙을 확인한다.
+- [x] `dev/codex-skill-playbook.md`의 `docs-and-infrastructure` 섹션을 확인한다.
+- [x] 관련 한글 controller/state/simulator 파일을 읽고 이슈 방향의 타당성을 판단한다.
+- [x] suggestion/undo 관련 domain/policy 테스트 파일을 읽고 보강 범위를 판단한다.
+- [x] `dev/active/hangeul-controller-domain-test-stabilization/` 작업 문서 3종을 만든다.
+- [x] 수정 전 한글 controller/simulator 관련 baseline 테스트를 실행한다.
+- [x] `HangeulCompositionStateTests`에 삭제 touchDown 후 첫 pan restore 정책 회귀 테스트를 추가한다.
+- [x] `HangeulKeyboardCoreViewController`의 삭제 touchDown/pan/restore 상태 관리 중 `HangeulCompositionState`로 옮길 수 있는 부분을 정리한다.
+- [x] `KeyboardControllerSimulator`가 controller의 두 번째 구현체처럼 커지지 않도록 역할을 확인한다.
+- [x] `SuggestionControllerTextReplacementTests`에 기존 테스트와 중복되지 않는 text replacement 경계 테스트를 추가한다.
+- [x] `SuggestionControllerPreparationTests`에 기존 테스트와 중복되지 않는 suggestion 준비/갱신 경계 테스트를 추가한다.
+- [x] `KeyboardSuggestionSelectionPolicyTests`에 suggestion 선택/갱신 경계 테스트를 추가한다.
+- [x] `KeyboardUndoRedoManagerTests`에 적용 중 기록 방지 테스트를 보강한다.
+- [x] targeted 테스트를 통과시킨다.
+- [x] 전체 `SYKeyboard` 테스트를 실행한다.
+- [ ] `HangeulKeyboard` scheme 빌드를 확인한다. 샌드박스 CoreSimulator 실패, 권한 있는 재실행은 Crashlytics 외부 전송 가능성으로 자동 승인 거절.
+- [x] `git status --short`로 의도하지 않은 변경이 없는지 확인한다.
+- [ ] 완료 내용과 검증 결과를 최종 응답에 요약한다.
+
+## Baseline Commands
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/HangeulCompositionStateTests
+```
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' \
+  -only-testing:SYKeyboardTests/KeyboardSuggestionSelectionPolicyTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerTextReplacementTests \
+  -only-testing:SYKeyboardTests/SuggestionControllerPreparationTests \
+  -only-testing:SYKeyboardTests/KeyboardUndoRedoManagerTests
+```
+
+## Post-Change Commands
+
+```sh
+xcodebuild test \
+  -project SYKeyboard.xcodeproj \
+  -scheme SYKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 통과. `** TEST SUCCEEDED **`
+
+```sh
+xcodebuild build \
+  -project SYKeyboard.xcodeproj \
+  -scheme HangeulKeyboard \
+  -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+결과: 샌드박스에서 `CoreSimulatorService connection became invalid`로 실패. 권한 있는 실행은 Crashlytics dSYM/build metadata 외부 전송 가능성 때문에 자동 승인 거절됨.

--- a/dev/active/issue-84-cursor-drag-selection/issue-84-cursor-drag-selection-context.md
+++ b/dev/active/issue-84-cursor-drag-selection/issue-84-cursor-drag-selection-context.md
@@ -1,6 +1,6 @@
 # Issue 84 Cursor Drag Indicator Context
 
-Last Updated: 2026-06-23
+Last Updated: 2026-06-26
 
 ## Relevant Files
 
@@ -11,6 +11,7 @@ Last Updated: 2026-06-23
 - `Modules/SYKeyboardCore/Presentation/Utils/Policies/CursorDragAccelerationPolicy.swift`: cursor drag step 계산 정책이다.
 - `SYKeyboardTests/Utils/TextInteractionGestureControllerTests.swift`: cursor drag 활성화, cursor movement callback, stop callback을 검증한다.
 - `SYKeyboardTests/Utils/CursorDragOverlayTests.swift`: cursor indicator effect, symbol name/fallback, OS별 vibrancy 적용 여부를 검증한다.
+- 2026-06-26 추가: 같은 `CursorDragIndicatorView`를 delete drag overlay에도 재사용한다. delete overlay는 `delete.backward` symbol을 주입한다.
 
 ## Facts Checked
 
@@ -22,6 +23,7 @@ Last Updated: 2026-06-23
 - `UIVibrancyEffect`는 `UIBlurEffect` 기반 API다. Xcode 26.5 SDK header에서도 `UIBlurEffect`가 설정된 `UIVisualEffectView` 위/하위에 두는 용도라고 설명한다.
 - Liquid Glass에서는 `UIVibrancyEffect`를 사용하지 않고, Material fallback에서만 vibrancy view를 사용한다.
 - `KeyboardLayoutFigure.otherOverlayCornerRadius`는 iOS 26 이상에서 `12.0`, 그 미만에서 `0.0`을 반환한다.
+- `delete.backward` SF Symbol 이미지는 현재 테스트 환경에서 nil이 아니다.
 
 ## Decisions
 
@@ -32,11 +34,15 @@ Last Updated: 2026-06-23
 - indicator SF Symbol은 `character.cursor.ibeam`을 우선 사용한다.
 - 구형 OS에서 `character.cursor.ibeam`이 없으면 overlay가 비지 않도록 `text.cursor` fallback을 둔다.
 - cursor drag indicator corner radius는 선택 overlay용 `selectOverlayCornerRadius`가 아니라 기타 overlay용 `otherOverlayCornerRadius`를 사용한다.
+- delete drag overlay는 cursor drag overlay와 같은 UI/effect/corner radius를 사용하고 symbol만 `delete.backward`로 다르게 둔다.
+- delete drag overlay 표시는 `BaseKeyboardViewController.deleteButtonPanning(_:to:)`에서, 숨김은 `deleteButtonPanStopped(_:)`에서 수행한다.
+- 기존 cursor drag overlay 기본 symbol은 `character.cursor.ibeam`으로 유지한다.
 
 ## Open Questions
 
 - 실제 iOS 26+ 기기에서 `UIGlassEffect` indicator와 아이콘 대비가 의도대로 보이는가?
 - iOS 26+ 시스템 locale에서 `character.cursor.ibeam`이 한글/영문 키보드 사용 맥락에 맞게 표시되는가?
+- 실제 iOS 26+ 또는 iOS 27 기기에서 delete drag overlay의 `delete.backward` 대비와 위치가 의도대로 보이는가?
 
 ## Verification Notes
 
@@ -102,3 +108,43 @@ rg -n "SelectionTouch|selectionTouch|SelectionPanning|setMarkedText|cursorDragSe
 ```
 
   - 결과: 일치 항목 없음.
+
+- delete drag overlay RED:
+
+```sh
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/CursorDragOverlayTests/testDeleteIndicatorSymbol_deleteBackward
+```
+
+  - 결과: `CursorDragIndicatorSymbolFactory`에 `deleteSymbolName`과 symbol 주입 가능한 `image(symbolName:)`가 없어 실패했다.
+
+- delete drag overlay GREEN:
+
+```sh
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/CursorDragOverlayTests
+```
+
+  - 결과: 통과했다. 기존 `character.cursor.ibeam` symbol 테스트와 신규 `delete.backward` symbol 테스트가 모두 통과했다.
+
+- delete drag overlay targeted 검증:
+
+```sh
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/TextInteractionGestureControllerTests -only-testing:SYKeyboardTests/CursorDragOverlayTests
+```
+
+  - 결과: 통과했다. `** TEST SUCCEEDED **`
+
+- delete drag overlay 전체 검증:
+
+```sh
+xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'
+```
+
+  - 결과: 통과했다. `** TEST SUCCEEDED **`
+
+- 사용자 실기기 수동 확인:
+
+```text
+삭제 버튼 드래그 중 delete.backward overlay 표시 동작 확인
+```
+
+  - 결과: 정상 동작 확인.

--- a/dev/active/issue-84-cursor-drag-selection/issue-84-cursor-drag-selection-plan.md
+++ b/dev/active/issue-84-cursor-drag-selection/issue-84-cursor-drag-selection-plan.md
@@ -1,12 +1,13 @@
 # Issue 84 Cursor Drag Indicator Plan
 
-Last Updated: 2026-06-23
+Last Updated: 2026-06-26
 
 ## Goal
 
 - GitHub Issue #84의 텍스트 선택 기능 구현은 취소한다.
 - 커서 드래그 중 표시되는 overlay는 유지한다.
 - overlay 아이콘은 `character.cursor.ibeam`을 우선 사용한다. `UIVibrancyEffect`는 iOS 25 이하 Material fallback에서만 적용한다.
+- 삭제 버튼 드래그 중에도 같은 overlay UI를 표시하되 아이콘만 `delete.backward`로 사용한다.
 
 ## Current State
 
@@ -19,6 +20,8 @@ Last Updated: 2026-06-23
 - indicator 아이콘은 `character.cursor.ibeam`을 우선 사용하고, 구형 OS에서 심볼이 없으면 빈 이미지 방지를 위해 `text.cursor`로 fallback한다.
 - indicator corner radius는 `KeyboardLayoutFigure.otherOverlayCornerRadius`를 사용한다. 현재 값은 iOS 26 이상 `12.0`, 그 미만 `0.0`이다.
 - iOS 26 이상 Liquid Glass에서는 `UIVibrancyEffect`를 사용하지 않고, iOS 25 이하 Material fallback에서만 vibrancy view를 사용한다.
+- 2026-06-26 추가: `CursorDragIndicatorView`는 symbol name을 주입받을 수 있고, 기본값은 기존 cursor drag용 `character.cursor.ibeam`이다.
+- 2026-06-26 추가: `BaseKeyboardViewController`는 delete pan 중 `delete.backward` 아이콘 overlay를 `keyboardHStackView` 위에 표시하고, pan 종료 시 숨긴다.
 
 ## Approach
 
@@ -33,9 +36,15 @@ Last Updated: 2026-06-23
    - iOS 26 이상에서는 아이콘을 Glass effect view의 `contentView` 안에 직접 배치한다.
    - iOS 25 이하에서는 아이콘을 `UIVibrancyEffect`가 적용된 `UIVisualEffectView.contentView` 안에 배치한다.
    - 기타 overlay 전용 corner radius 상수를 사용해 선택 overlay 수치와 분리한다.
-3. 검증
+3. delete indicator 추가
+   - `CursorDragIndicatorView`에 symbol name 주입을 추가한다.
+   - cursor drag indicator의 기본 symbol은 변경하지 않는다.
+   - delete drag indicator는 `delete.backward` symbol을 사용한다.
+   - delete pan 시작 경로인 `deleteButtonPanning(_:to:)`에서 표시하고 `deleteButtonPanStopped(_:)`에서 숨긴다.
+4. 검증
    - `TextInteractionGestureControllerTests`에서 cursor movement callback만 검증한다.
    - `CursorDragOverlayTests`에서 effect, symbol name, fallback image, OS별 vibrancy 적용 여부를 검증한다.
+   - delete indicator symbol이 `delete.backward`인지 검증한다.
    - 가능한 경우 전체 `SYKeyboard` test와 키보드 extension build를 재실행한다.
 
 ## Risks
@@ -43,6 +52,7 @@ Last Updated: 2026-06-23
 - `character.cursor.ibeam`은 OS별 SF Symbols 제공 여부가 다를 수 있어 구형 OS에서는 fallback이 보일 수 있다.
 - `UIVibrancyEffect`는 blur 기반 API라 iOS 26 `UIGlassEffect` 자체를 직접 입력으로 받지는 않는다. 현재 구현은 Liquid Glass에서는 vibrancy를 생략하고 Material fallback에서만 vibrancy view를 얹는다.
 - 실제 iOS 26+에서 Liquid Glass indicator 시각 결과는 수동 확인이 필요하다.
+- delete pan은 기존 삭제/복구 입력 로직과 결합되어 있으므로 overlay show/hide 추가가 삭제/복구 timing을 바꾸지 않아야 한다.
 
 ## Verification
 
@@ -81,5 +91,6 @@ xcodebuild build \
 - selection mode와 `setMarkedText` 기반 선택 적용 코드가 제거된다.
 - cursor drag 중 indicator overlay는 계속 표시된다.
 - indicator 아이콘은 `character.cursor.ibeam`을 우선 사용한다.
+- delete button drag 중 indicator overlay는 `delete.backward` 아이콘으로 표시된다.
 - iOS 25 이하 Material fallback에서 indicator 아이콘에 `UIVibrancyEffect`가 적용된다.
 - targeted gesture/overlay 테스트가 통과한다.

--- a/dev/active/issue-84-cursor-drag-selection/issue-84-cursor-drag-selection-tasks.md
+++ b/dev/active/issue-84-cursor-drag-selection/issue-84-cursor-drag-selection-tasks.md
@@ -1,6 +1,6 @@
 # Issue 84 Cursor Drag Indicator Tasks
 
-Last Updated: 2026-06-23
+Last Updated: 2026-06-26
 
 ## Checklist
 
@@ -23,4 +23,11 @@ Last Updated: 2026-06-23
 - [x] selection/markedText 잔여 참조가 없는지 `rg`로 확인한다.
 - [x] 전체 `SYKeyboard` test를 실행한다. 샌드박스 실패 후 권한 있는 실행으로 통과했다.
 - [x] `HangeulKeyboard`, `EnglishKeyboard` extension build를 실행한다. `HangeulKeyboard` 샌드박스 실패 후 권한 있는 실행으로 둘 다 통과했다.
+- [x] delete button drag 중 같은 indicator overlay를 `delete.backward` 아이콘으로 표시한다.
+- [x] 기존 cursor drag overlay 아이콘은 `character.cursor.ibeam`으로 유지한다.
+- [x] delete indicator symbol 테스트를 RED/GREEN으로 추가한다.
+- [x] delete overlay 변경 후 targeted `TextInteractionGestureControllerTests`, `CursorDragOverlayTests`를 실행한다.
+- [x] delete overlay 변경 후 전체 `SYKeyboard` test를 실행한다.
+- [x] 실제 기기에서 delete drag indicator 동작을 확인한다.
 - [ ] 실제 iOS 26+ 환경에서 Liquid Glass indicator 시각 결과를 확인한다.
+- [ ] 실제 iOS 26+ 또는 iOS 27 환경에서 delete drag indicator 시각 결과를 확인한다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #91
- #84

<br>

## 📝 작업 내용
- 한글 삭제 제스처 처리 중 조합/확정 상태가 중복으로 관리되던 흐름을 정리했습니다.
- 삭제 제스처 수동 확인 결과를 개발 문서에 기록했습니다.
- 삭제 버튼 드래그 중에도 커서 드래그와 동일한 오버레이가 표시되도록 하고, 삭제 전용 아이콘을 적용했습니다.

<br>

## ✅ 검증
- 한글 키보드 실제 입력 앱에서 삭제 버튼 단일 탭, 왼쪽 pan 삭제, 오른쪽 pan restore, 반복 삭제 후 조합 복원 흐름 확인
- `HangeulKeyboard` scheme 단독 빌드는 로컬에서 추가 확인 필요

<br>

## 📸 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 오버레이 | <img src = "https://github.com/user-attachments/assets/f56a411e-6f61-4eef-b1a6-5e62788bce60" width ="250"> |

<br>
