### PR TITLE
Fix/#94 iOS 27 키보드 높이 방향 판단 개선

### DIFF
--- a/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardHeightPolicy.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardHeightPolicy.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreGraphics
+import UIKit
 
 enum KeyboardHeightPolicy {
 
@@ -33,6 +34,53 @@ enum KeyboardHeightPolicy {
                 keyboardViewHeight: landscapeKeyboardHeight,
                 keyboardHStackViewHeight: landscapeKeyboardHeight - visibleSuggestionBarHeight
             )
+        }
+    }
+
+    static func isPortrait(
+        orientation: UIInterfaceOrientation,
+        usesOrientation: Bool = true,
+        fallbackBounds: CGRect,
+        horizontalSizeClass: UIUserInterfaceSizeClass = .unspecified,
+        verticalSizeClass: UIUserInterfaceSizeClass = .unspecified
+    ) -> Bool {
+        if usesOrientation == false {
+            return isPortrait(
+                horizontalSizeClass: horizontalSizeClass,
+                verticalSizeClass: verticalSizeClass
+            ) ?? (fallbackBounds.height >= fallbackBounds.width)
+        }
+
+        switch orientation {
+        case .portrait, .portraitUpsideDown:
+            return true
+        case .landscapeLeft, .landscapeRight:
+            return false
+        case .unknown:
+            if let traitIsPortrait = isPortrait(
+                horizontalSizeClass: horizontalSizeClass,
+                verticalSizeClass: verticalSizeClass
+            ) {
+                return traitIsPortrait
+            }
+
+            return fallbackBounds.height >= fallbackBounds.width
+        @unknown default:
+            return fallbackBounds.height >= fallbackBounds.width
+        }
+    }
+
+    private static func isPortrait(
+        horizontalSizeClass: UIUserInterfaceSizeClass,
+        verticalSizeClass: UIUserInterfaceSizeClass
+    ) -> Bool? {
+        switch (horizontalSizeClass, verticalSizeClass) {
+        case (.compact, .regular):
+            return true
+        case (.compact, .compact), (.regular, .compact):
+            return false
+        default:
+            return nil
         }
     }
 }

--- a/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardHeightPolicy.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardHeightPolicy.swift
@@ -44,7 +44,7 @@ enum KeyboardHeightPolicy {
         horizontalSizeClass: UIUserInterfaceSizeClass = .unspecified,
         verticalSizeClass: UIUserInterfaceSizeClass = .unspecified
     ) -> Bool {
-        if usesOrientation == false {
+        if !usesOrientation {
             return isPortrait(
                 horizontalSizeClass: horizontalSizeClass,
                 verticalSizeClass: verticalSizeClass

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -701,8 +701,9 @@ private extension BaseKeyboardViewController {
     }
 
     func setKeyboardHeight() {
-        guard let window = self.view.window,
-              let orientation = window.windowScene?.effectiveGeometry.interfaceOrientation else { return }
+        guard let window = self.view.window else { return }
+        let windowScene = window.windowScene
+        let orientation = windowScene?.effectiveGeometry.interfaceOrientation ?? .unknown
 
         let isSuggestionBarVisible = !KeyboardPresentationStatePolicy.shouldHideSuggestionBar(
             isPredictiveTextEnabled: suggestionController.isPredictiveTextEnabled,
@@ -710,12 +711,20 @@ private extension BaseKeyboardViewController {
             currentKeyboard: currentKeyboard
         )
 
+        let isPortrait = KeyboardHeightPolicy.isPortrait(
+            orientation: orientation,
+            usesOrientation: usesInterfaceOrientationForKeyboardHeight,
+            fallbackBounds: window.bounds,
+            horizontalSizeClass: traitCollection.horizontalSizeClass,
+            verticalSizeClass: traitCollection.verticalSizeClass
+        )
+
         let height = KeyboardHeightPolicy.height(
             keyboardSettingsHeight: keyboardSettingsManager.keyboardHeight,
             landscapeKeyboardHeight: KeyboardLayoutFigure.landscapeKeyboardHeight,
             suggestionBarHeight: KeyboardLayoutFigure.suggestionBarHeightWithTopSpacing,
             isSuggestionBarVisible: isSuggestionBarVisible,
-            isPortrait: orientation == .portrait
+            isPortrait: isPortrait
         )
 
         if let keyboardViewHeightConstraint {
@@ -733,6 +742,14 @@ private extension BaseKeyboardViewController {
             let heightConstraint = keyboardHStackView.heightAnchor.constraint(equalToConstant: height.keyboardHStackViewHeight)
             heightConstraint.isActive = true
             keyboardHStackViewHeightConstraint = heightConstraint
+        }
+    }
+
+    var usesInterfaceOrientationForKeyboardHeight: Bool {
+        if #available(iOS 27.0, *) {
+            return false
+        } else {
+            return true
         }
     }
 
@@ -1047,7 +1064,9 @@ private extension BaseKeyboardViewController {
 
         if prevSuggestionHiddenState != shouldHideSuggestions {
             DispatchQueue.main.async { [weak self] in
-                self?.setKeyboardHeight()
+                guard let self else { return }
+
+                self.setKeyboardHeight()
             }
         }
     }

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -748,9 +748,8 @@ private extension BaseKeyboardViewController {
     var usesInterfaceOrientationForKeyboardHeight: Bool {
         if #available(iOS 27.0, *) {
             return false
-        } else {
-            return true
         }
+        return true
     }
 
     func setNextKeyboardButton() {

--- a/SYKeyboardTests/Utils/KeyboardHeightPolicyTests.swift
+++ b/SYKeyboardTests/Utils/KeyboardHeightPolicyTests.swift
@@ -5,13 +5,72 @@
 //  Created by Codex on 6/1/26.
 //
 
-import CoreFoundation
 import Testing
+import UIKit
 
 @testable import SYKeyboardCore
 
 @Suite("키보드 높이 정책 검증")
 struct KeyboardHeightPolicyTests {
+
+    @Test("orientation이 unknown이면 bounds 비율로 세로 화면을 판단")
+    func testUnknownOrientation_bounds세로비율_fallback() {
+        let isPortrait = KeyboardHeightPolicy.isPortrait(
+            orientation: .unknown,
+            fallbackBounds: CGRect(x: 0, y: 0, width: 430, height: 932)
+        )
+
+        #expect(isPortrait)
+    }
+
+    @Test("orientation이 unknown이면 iPhone portrait trait 조합을 세로 화면으로 판단")
+    func testUnknownOrientation_iPhonePortraitTrait세로판단() {
+        let isPortrait = KeyboardHeightPolicy.isPortrait(
+            orientation: .unknown,
+            fallbackBounds: CGRect(x: 0, y: 0, width: 932, height: 430),
+            horizontalSizeClass: .compact,
+            verticalSizeClass: .regular
+        )
+
+        #expect(isPortrait)
+    }
+
+    @Test("orientation이 unknown이면 일반 iPhone landscape trait 조합을 가로 화면으로 판단")
+    func testUnknownOrientation_iPhoneCompactLandscapeTrait가로판단() {
+        let isPortrait = KeyboardHeightPolicy.isPortrait(
+            orientation: .unknown,
+            fallbackBounds: CGRect(x: 0, y: 0, width: 430, height: 932),
+            horizontalSizeClass: .compact,
+            verticalSizeClass: .compact
+        )
+
+        #expect(isPortrait == false)
+    }
+
+    @Test("orientation이 unknown이면 Max 계열 iPhone landscape trait 조합을 가로 화면으로 판단")
+    func testUnknownOrientation_iPhoneRegularLandscapeTrait가로판단() {
+        let isPortrait = KeyboardHeightPolicy.isPortrait(
+            orientation: .unknown,
+            fallbackBounds: CGRect(x: 0, y: 0, width: 430, height: 932),
+            horizontalSizeClass: .regular,
+            verticalSizeClass: .compact
+        )
+
+        #expect(isPortrait == false)
+    }
+
+    @Test("orientation을 사용하지 않는 환경에서는 trait 조합을 우선 사용")
+    func testOrientation미사용환경_trait조합우선() {
+        let isPortrait = KeyboardHeightPolicy.isPortrait(
+            orientation: .portrait,
+            usesOrientation: false,
+            fallbackBounds: CGRect(x: 0, y: 0, width: 430, height: 932),
+            horizontalSizeClass: .compact,
+            verticalSizeClass: .compact
+        )
+
+        #expect(isPortrait == false)
+    }
 
     @Test("세로 화면에서는 키보드 높이에 suggestion bar 높이를 더하고 hstack 높이는 설정값을 유지")
     func test세로화면_높이계산() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #94

<br>

## 📝 작업 내용
- 키보드 높이 계산에서 세로/가로 판단을 `KeyboardHeightPolicy`로 분리했습니다.
- iOS 27 이상에서는 `UIInterfaceOrientation`을 레이아웃 판단에 사용하지 않고 size class 조합을 우선 사용하도록 변경했습니다.
- iOS 26 이하에서는 기존 orientation 우선 동작을 유지하고, orientation이 불명확한 경우 size class와 bounds fallback을 사용하도록 했습니다.
- iPhone portrait, 일반 iPhone landscape, Max 계열 landscape, orientation 미사용 환경에 대한 회귀 테스트를 추가했습니다.

<br>

## ✅ 검증
- `xcodebuild -quiet test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0' -only-testing:SYKeyboardTests/KeyboardHeightPolicyTests`
  - 결과: 통과
- `xcodebuild -quiet build -project SYKeyboard.xcodeproj -scheme HangeulKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - 결과: 통과
- 실제 기기 iOS 27에서 세로 최초 표시, 가로 최초 표시, 세로↔가로 전환 후 높이 확인은 별도 수동 확인 필요

<br>

## 📸 스크린샷
|    상황    |   수정 이전   |   수정 이후   |
| :-------------: | :-------------: | :----------: |
| 세로 → 가로 | <img src = "https://github.com/user-attachments/assets/4e839abf-6f2e-49fb-89bf-3c13c958c49f" width ="250"> | <img src = "https://github.com/user-attachments/assets/0ed3df7e-0a72-4005-bd2b-fdfc3f8f657d" width ="250"> |
| 가로 → 세로 | <img src = "https://github.com/user-attachments/assets/96aecf36-ca86-4c33-98c1-a0c7c4d5efc1" width ="250"> | <img src = "https://github.com/user-attachments/assets/67fa84d1-20d0-49f5-a5a8-f007d167411e" width ="250"> |

<br>
