### PR TITLE
Fix/#96 Xcode 27 키보드 가장자리 터치 딜레이 개선

### DIFF
--- a/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardGesturePolicy.swift
+++ b/Modules/SYKeyboardCore/Presentation/Utils/Policies/KeyboardGesturePolicy.swift
@@ -5,6 +5,8 @@
 //  Created by Codex on 5/22/26.
 //
 
+import UIKit
+
 enum KeyboardGesturePolicy {
 
     static func shouldAddTextInteractionGestures(
@@ -43,5 +45,15 @@ enum KeyboardGesturePolicy {
         isDeleteButton: Bool
     ) -> Bool {
         return selectedLongPressAction == .numberInput && !isDeleteButton
+    }
+
+    static func configureSystemGestureForEdgeTouch(_ gesture: UIGestureRecognizer) {
+        gesture.delaysTouchesBegan = false
+        gesture.delaysTouchesEnded = false
+        gesture.cancelsTouchesInView = false
+
+        if gesture is UIScreenEdgePanGestureRecognizer {
+            gesture.isEnabled = false
+        }
     }
 }

--- a/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
+++ b/Modules/SYKeyboardCore/Presentation/ViewController/Bases/BaseKeyboardViewController.swift
@@ -210,6 +210,10 @@ open class BaseKeyboardViewController: UIInputViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    open override var preferredScreenEdgesDeferringSystemGestures: UIRectEdge {
+        return [.left, .right]
+    }
+
     deinit {
         logger.debug("\(String(describing: type(of: self))) deinit")
     }
@@ -248,6 +252,7 @@ open class BaseKeyboardViewController: UIInputViewController {
         }
 
         updateSuggestionBarHidden()
+        updateEdgeTouchSystemGesturePolicy()
     }
 
     open override func viewWillAppear(_ animated: Bool) {
@@ -258,6 +263,7 @@ open class BaseKeyboardViewController: UIInputViewController {
         logger.debug("viewWillAppear")
         if !BaseKeyboardViewController.isPreview { setKeyboardHeight() }
         FeedbackManager.shared.prepareHaptic()
+        updateEdgeTouchSystemGesturePolicy()
     }
 
     open override func viewDidAppear(_ animated: Bool) {
@@ -266,10 +272,7 @@ open class BaseKeyboardViewController: UIInputViewController {
         defer { performanceSignposter.endInterval("KeyboardViewDidAppear", state) }
 
         super.viewDidAppear(animated)
-        let systemGestureRecognizer0 = self.view.window?.gestureRecognizers?[0] as? UIGestureRecognizer
-        let systemGestureRecognizer1 = self.view.window?.gestureRecognizers?[1] as? UIGestureRecognizer
-        systemGestureRecognizer0?.delaysTouchesBegan = false
-        systemGestureRecognizer1?.delaysTouchesBegan = false
+        updateEdgeTouchSystemGesturePolicy()
         startDeferredSuggestionPreparationIfNeeded()
     }
 
@@ -822,6 +825,40 @@ private extension BaseKeyboardViewController {
             return false
         }
         return true
+    }
+
+    func updateEdgeTouchSystemGesturePolicy() {
+        guard !BaseKeyboardViewController.isPreview else { return }
+
+        setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
+        edgeTouchSystemGestureHostViews().forEach { hostView in
+            hostView.gestureRecognizers?.forEach {
+                KeyboardGesturePolicy.configureSystemGestureForEdgeTouch($0)
+            }
+        }
+    }
+
+    func edgeTouchSystemGestureHostViews() -> [UIView] {
+        var hostViews: [UIView] = []
+        var visitedIDs = Set<ObjectIdentifier>()
+
+        func appendIfNeeded(_ view: UIView?) {
+            guard let view else { return }
+            let id = ObjectIdentifier(view)
+            guard !visitedIDs.contains(id) else { return }
+            visitedIDs.insert(id)
+            hostViews.append(view)
+        }
+
+        appendIfNeeded(view.window)
+
+        var parentView = view.superview
+        while let currentView = parentView {
+            appendIfNeeded(currentView)
+            parentView = currentView.superview
+        }
+
+        return hostViews
     }
 
     func setNextKeyboardButton() {

--- a/SYKeyboardTests/Utils/KeyboardGesturePolicyTests.swift
+++ b/SYKeyboardTests/Utils/KeyboardGesturePolicyTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import UIKit
 
 @testable import SYKeyboardCore
 
@@ -130,5 +131,29 @@ struct KeyboardGesturePolicyTests {
                 isDeleteButton: true
             ) == false
         )
+    }
+
+    @Test("system gesture recognizer는 edge key touch 지연과 취소를 비활성화")
+    func testSystemGestureTouchDelay해제정책() {
+        let gesture = UIGestureRecognizer()
+        gesture.delaysTouchesBegan = true
+        gesture.delaysTouchesEnded = true
+        gesture.cancelsTouchesInView = true
+
+        KeyboardGesturePolicy.configureSystemGestureForEdgeTouch(gesture)
+
+        #expect(gesture.delaysTouchesBegan == false)
+        #expect(gesture.delaysTouchesEnded == false)
+        #expect(gesture.cancelsTouchesInView == false)
+    }
+
+    @Test("screen edge pan gesture는 edge key touch를 가로채지 않도록 비활성화")
+    func testScreenEdgePanGesture비활성화정책() {
+        let gesture = UIScreenEdgePanGestureRecognizer()
+        gesture.isEnabled = true
+
+        KeyboardGesturePolicy.configureSystemGestureForEdgeTouch(gesture)
+
+        #expect(gesture.isEnabled == false)
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #96

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 키보드 extension이 좌우 화면 가장자리의 system gesture defer를 요청하도록 적용했습니다.
- view 생명주기에서 edge touch system gesture 정책을 갱신하고, host view 계층의 gesture recognizer가 터치를 지연하거나 취소하지 않도록 설정했습니다.
- `UIScreenEdgePanGestureRecognizer`가 가장자리 키 입력을 가로채지 않도록 비활성화했습니다.
- system gesture 정책 회귀 테스트를 추가했습니다.

<br>

## ✅ 검증
<!-- 실행한 빌드/테스트 명령과 결과를 작성해주세요. 실행하지 못했다면 이유를 적어주세요. -->
- `xcodebuild test -project SYKeyboard.xcodeproj -scheme SYKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - 결과: 성공, 255개 테스트 통과 (`failed: 0`)
- `xcodebuild build -project SYKeyboard.xcodeproj -scheme HangeulKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - 결과: 성공
- `xcodebuild build -project SYKeyboard.xcodeproj -scheme EnglishKeyboard -destination 'platform=iOS Simulator,name=iPhone 13 mini,OS=16.0'`
  - 결과: 성공

<!-- Codex 샌드박스 오류로 재실행한 경우 일반 실행 실패와 권한 있는 실행 결과를 구분해서 적어주세요. -->

<br>